### PR TITLE
Ee 5714/unknown partner wrong nino in error

### DIFF
--- a/src/main/java/uk/gov/digital/ho/proving/income/application/ApplicationExceptions.java
+++ b/src/main/java/uk/gov/digital/ho/proving/income/application/ApplicationExceptions.java
@@ -17,6 +17,13 @@ public interface ApplicationExceptions {
     }
 
     class EarningsServiceNoUniqueMatchException extends RuntimeException {
+        private String nino;
+        public EarningsServiceNoUniqueMatchException(String nino) {
+            this.nino = nino;
+        }
+        public String nino() {
+            return nino;
+        }
     }
 
     class InvalidNationalInsuranceNumber extends IllegalArgumentException {

--- a/src/main/java/uk/gov/digital/ho/proving/income/application/ResourceExceptionHandler.java
+++ b/src/main/java/uk/gov/digital/ho/proving/income/application/ResourceExceptionHandler.java
@@ -77,8 +77,9 @@ public class ResourceExceptionHandler {
     @ExceptionHandler(value = ApplicationExceptions.EarningsServiceNoUniqueMatchException.class)
     public ResponseEntity<BaseResponse> handle(ApplicationExceptions.EarningsServiceNoUniqueMatchException e, WebRequest request) {
         log.error(append("errorCode", "0009"), "Could not retrieve earning details.", e);
-        auditClient.add(INCOME_PROVING_FINANCIAL_STATUS_RESPONSE, UUID.randomUUID(), auditData(new BaseResponse(new ResponseStatus("0009", "Resource not found"))));
-        return buildErrorResponse(httpHeaders(), "0009", "Resource not found", HttpStatus.NOT_FOUND);
+        String errorMessage = String.format("Resource not found: %s", e.nino());
+        auditClient.add(INCOME_PROVING_FINANCIAL_STATUS_RESPONSE, UUID.randomUUID(), auditData(new BaseResponse(new ResponseStatus("0009", errorMessage))));
+        return buildErrorResponse(httpHeaders(), "0009", errorMessage, HttpStatus.NOT_FOUND);
     }
 
     private Map<String, Object> auditData(BaseResponse response) {

--- a/src/main/java/uk/gov/digital/ho/proving/income/application/ResourceExceptionHandler.java
+++ b/src/main/java/uk/gov/digital/ho/proving/income/application/ResourceExceptionHandler.java
@@ -13,6 +13,7 @@ import org.springframework.web.bind.annotation.ResponseBody;
 import org.springframework.web.context.request.WebRequest;
 import org.springframework.web.method.annotation.MethodArgumentTypeMismatchException;
 import org.springframework.web.servlet.NoHandlerFoundException;
+import uk.gov.digital.ho.proving.income.api.NinoUtils;
 import uk.gov.digital.ho.proving.income.api.domain.BaseResponse;
 import uk.gov.digital.ho.proving.income.api.domain.ResponseStatus;
 import uk.gov.digital.ho.proving.income.application.ApplicationExceptions.AuditDataException;
@@ -31,9 +32,11 @@ import static uk.gov.digital.ho.proving.income.audit.AuditEventType.INCOME_PROVI
 public class ResourceExceptionHandler {
 
     private final AuditClient auditClient;
+    private final NinoUtils ninoUtils;
 
-    public ResourceExceptionHandler(AuditClient auditClient) {
+    public ResourceExceptionHandler(AuditClient auditClient, NinoUtils ninoUtils) {
         this.auditClient = auditClient;
+        this.ninoUtils = ninoUtils;
     }
 
 
@@ -75,9 +78,9 @@ public class ResourceExceptionHandler {
     }
 
     @ExceptionHandler(value = ApplicationExceptions.EarningsServiceNoUniqueMatchException.class)
-    public ResponseEntity<BaseResponse> handle(ApplicationExceptions.EarningsServiceNoUniqueMatchException e, WebRequest request) {
+    public ResponseEntity<BaseResponse> handle(ApplicationExceptions.EarningsServiceNoUniqueMatchException e) {
         log.error(append("errorCode", "0009"), "Could not retrieve earning details.", e);
-        String errorMessage = String.format("Resource not found: %s", e.nino());
+        String errorMessage = String.format("Resource not found: %s", ninoUtils.redact(e.nino()));
         auditClient.add(INCOME_PROVING_FINANCIAL_STATUS_RESPONSE, UUID.randomUUID(), auditData(new BaseResponse(new ResponseStatus("0009", errorMessage))));
         return buildErrorResponse(httpHeaders(), "0009", errorMessage, HttpStatus.NOT_FOUND);
     }

--- a/src/main/java/uk/gov/digital/ho/proving/income/hmrc/HmrcClient.java
+++ b/src/main/java/uk/gov/digital/ho/proving/income/hmrc/HmrcClient.java
@@ -79,7 +79,7 @@ public class HmrcClient {
         } catch (HttpStatusCodeException e) {
             if (isNotFound(e)) {
                 log.error("Income Service found no match");
-                throw new ApplicationExceptions.EarningsServiceNoUniqueMatchException();
+                throw new ApplicationExceptions.EarningsServiceNoUniqueMatchException(identity.nino());
             }
             log.error("Income Service failed", e);
             throw e;

--- a/src/test/groovy/steps/ProvingThingsApiSteps.groovy
+++ b/src/test/groovy/steps/ProvingThingsApiSteps.groovy
@@ -361,8 +361,24 @@ class ProvingThingsApiSteps implements ApplicationContextAware {
     @Given("^HMRC has no matching record\$")
     void hmrcHasNoMatchingRecord() throws Throwable {
         stubFor(WireMock.get(urlMatching("/income.*")).
+            inScenario("hmrc applicants").
+            whenScenarioStateIs(Scenario.STARTED).
             willReturn(aResponse().
                 withHeader("Content-Type", "application/json").
-                withStatus(404)))
+                withStatus(404)).
+            willSetStateTo("main applicant returned"))
+
+    }
+
+    @Given("^the applicants partner has no matching record\$")
+    void partnerHasNoMatchingRecord() throws Throwable {
+        stubFor(WireMock.get(urlMatching("/income.*")).
+            inScenario("hmrc applicants").
+            whenScenarioStateIs("main applicant returned").
+            willReturn(aResponse().
+                withHeader("Content-Type", "application/json").
+                withStatus(404)).
+            willSetStateTo("finished"))
+
     }
 }

--- a/src/test/java/uk/gov/digital/ho/proving/income/api/FinancialStatusServiceTest.java
+++ b/src/test/java/uk/gov/digital/ho/proving/income/api/FinancialStatusServiceTest.java
@@ -11,6 +11,7 @@ import uk.gov.digital.ho.proving.income.api.domain.Applicant;
 import uk.gov.digital.ho.proving.income.api.domain.FinancialStatusCheckResponse;
 import uk.gov.digital.ho.proving.income.api.domain.FinancialStatusRequest;
 import uk.gov.digital.ho.proving.income.api.domain.Individual;
+import uk.gov.digital.ho.proving.income.application.ApplicationExceptions;
 import uk.gov.digital.ho.proving.income.audit.AuditClient;
 import uk.gov.digital.ho.proving.income.hmrc.HmrcClient;
 import uk.gov.digital.ho.proving.income.hmrc.domain.Identity;
@@ -64,8 +65,8 @@ public class FinancialStatusServiceTest {
         when(mockFinancialStatusRequest.applicationRaisedDate()).thenReturn(fiveDaysAgo);
         when(mockHmrcClient.getIncomeRecord(any(), any(), any())).thenReturn(mock(IncomeRecord.class));
 
-        LogCapturer<FinancialStatusService> logCapturer = LogCapturer.forClass(FinancialStatusService.class);
-        logCapturer.start();
+            LogCapturer<FinancialStatusService> logCapturer = LogCapturer.forClass(FinancialStatusService.class);
+            logCapturer.start();
 
         // when
         service.getFinancialStatus(mockFinancialStatusRequest);

--- a/src/test/java/uk/gov/digital/ho/proving/income/application/ResourceExceptionHandlerTest.java
+++ b/src/test/java/uk/gov/digital/ho/proving/income/application/ResourceExceptionHandlerTest.java
@@ -1,0 +1,49 @@
+package uk.gov.digital.ho.proving.income.application;
+
+import ch.qos.logback.classic.spi.ILoggingEvent;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.runners.MockitoJUnitRunner;
+import uk.gov.digital.ho.proving.income.api.NinoUtils;
+import uk.gov.digital.ho.proving.income.audit.AuditClient;
+import utils.LogCapturer;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.when;
+
+@RunWith(MockitoJUnitRunner.class)
+public class ResourceExceptionHandlerTest {
+
+    @InjectMocks
+    private ResourceExceptionHandler resourceExceptionHandler;
+
+    @Mock
+    private NinoUtils ninoUtils;
+
+    @Mock
+    private AuditClient auditClient;
+
+    @Test
+    public void thatNotFoundExceptionDoesNotLogFullNino() {
+        LogCapturer<ResourceExceptionHandler> logCapturer = LogCapturer.forClass(ResourceExceptionHandler.class);
+        logCapturer.start();
+
+        String realNino = "RealNino";
+        String redactedNino = "RedadactedNino";
+
+        when(ninoUtils.redact(realNino)).thenReturn(redactedNino);
+
+        resourceExceptionHandler.handle(new ApplicationExceptions.EarningsServiceNoUniqueMatchException(realNino));
+
+        List<ILoggingEvent> allLogEvents = logCapturer.getAllEvents();
+        for (final ILoggingEvent logEvent : allLogEvents) {
+            final String logMessage = logEvent.getFormattedMessage();
+            assertThat(logMessage).doesNotContain(realNino);
+        }
+    }
+
+}

--- a/src/test/java/uk/gov/digital/ho/proving/income/hmrc/HmrcClientTest.java
+++ b/src/test/java/uk/gov/digital/ho/proving/income/hmrc/HmrcClientTest.java
@@ -227,7 +227,7 @@ public class HmrcClientTest {
 
         thrown.expect(ApplicationExceptions.EarningsServiceNoUniqueMatchException.class);
 
-        ApplicationExceptions.EarningsServiceNoUniqueMatchException exception = new ApplicationExceptions.EarningsServiceNoUniqueMatchException();
+        ApplicationExceptions.EarningsServiceNoUniqueMatchException exception = new ApplicationExceptions.EarningsServiceNoUniqueMatchException("nino");
 
         service.getIncomeRecordFailureRecovery(exception);
     }

--- a/src/test/specs/API-v2/TMFM10_Validation for information on the TM Familly Casworker tool.feature
+++ b/src/test/specs/API-v2/TMFM10_Validation for information on the TM Familly Casworker tool.feature
@@ -166,7 +166,7 @@ Feature: Validation of the API fields and data
         Then The Income Proving TM Family API provides the following result:
             | Http Response | HTTP Status | 404                           |
             | Status        | code        | 0009                          |
-            | Status        | message     | Resource not found: SP128856A |
+            | Status        | message     | Resource not found: SP128**** |
 
     Scenario: The partner's NINO is not found by HMRC, correct NINO is reported in error
         Given HMRC has the following income records:
@@ -180,7 +180,7 @@ Feature: Validation of the API fields and data
         Then The Income Proving TM Family API provides the following result:
             | Http Response | HTTP Status | 404                           |
             | Status        | code        | 0009                          |
-            | Status        | message     | Resource not found: BB345678A |
+            | Status        | message     | Resource not found: BB345**** |
 
     Scenario: The API is provided with a valid NINO and a future application raised date
         Given A service is consuming the Income Proving TM Family API

--- a/src/test/specs/API-v2/TMFM10_Validation for information on the TM Familly Casworker tool.feature
+++ b/src/test/specs/API-v2/TMFM10_Validation for information on the TM Familly Casworker tool.feature
@@ -164,9 +164,23 @@ Feature: Validation of the API fields and data
             | Application Raised Date | 2015-01-01 |
             | Dependants              | 3          |
         Then The Income Proving TM Family API provides the following result:
-            | Http Response | HTTP Status | 404                |
-            | Status        | code        | 0009               |
-            | Status        | message     | Resource not found |
+            | Http Response | HTTP Status | 404                           |
+            | Status        | code        | 0009                          |
+            | Status        | message     | Resource not found: SP128856A |
+
+    Scenario: The partner's NINO is not found by HMRC, correct NINO is reported in error
+        Given HMRC has the following income records:
+            | Date       | Amount  | Week Number | Month Number | PAYE Reference | Employer         |
+            | 2018-04-09 | 3066.67 |             | 01           | FP/Ref1        | Flying Pizza Ltd |
+        And the applicants partner has no matching record
+        When the Income Proving v3 TM Family API is invoked with the following:
+            | NINO - Applicant        | AA345678A  |
+            | NINO - Partner          | BB345678A  |
+            | Application Raised Date | 2015-01-01 |
+        Then The Income Proving TM Family API provides the following result:
+            | Http Response | HTTP Status | 404                           |
+            | Status        | code        | 0009                          |
+            | Status        | message     | Resource not found: BB345678A |
 
     Scenario: The API is provided with a valid NINO and a future application raised date
         Given A service is consuming the Income Proving TM Family API


### PR DESCRIPTION
Return the nino in the error message so we can let the end user know which one failed