### PR TITLE
EE-6991 Rename "hmrcIndividual" to "individual"

### DIFF
--- a/src/main/java/uk/gov/digital/ho/proving/income/api/FinancialStatusService.java
+++ b/src/main/java/uk/gov/digital/ho/proving/income/api/FinancialStatusService.java
@@ -36,7 +36,7 @@ public class FinancialStatusService {
                 startSearchDate,
                 applicationRaisedDate);
 
-            incomeRecords.put(individualFromRequestAndRecord(applicant, incomeRecord.hmrcIndividual(), applicant.nino()), incomeRecord);
+            incomeRecords.put(individualFromRequestAndRecord(applicant, incomeRecord.individual(), applicant.nino()), incomeRecord);
         }
 
         return incomeRecords;

--- a/src/main/java/uk/gov/digital/ho/proving/income/hmrc/domain/IncomeRecord.java
+++ b/src/main/java/uk/gov/digital/ho/proving/income/hmrc/domain/IncomeRecord.java
@@ -23,7 +23,7 @@ public class IncomeRecord {
     @JsonProperty
     private List<Employments> employments;
     @JsonProperty
-    private HmrcIndividual hmrcIndividual;
+    private HmrcIndividual individual;
 
     public List<Income> deDuplicatedIncome() {
 
@@ -33,7 +33,7 @@ public class IncomeRecord {
     }
 
     public LocalDate dateOfBirth() {
-        return hmrcIndividual != null?hmrcIndividual.dateOfBirth():null;
+        return individual != null? individual.dateOfBirth():null;
     }
 }
 

--- a/src/test/java/uk/gov/digital/ho/proving/income/hmrc/domain/HmrcIndividualTest.java
+++ b/src/test/java/uk/gov/digital/ho/proving/income/hmrc/domain/HmrcIndividualTest.java
@@ -1,0 +1,27 @@
+package uk.gov.digital.ho.proving.income.hmrc.domain;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.Test;
+import uk.gov.digital.ho.proving.income.application.ServiceConfiguration;
+
+import java.io.IOException;
+import java.time.LocalDate;
+
+import static org.assertj.core.api.Java6Assertions.assertThat;
+
+public class HmrcIndividualTest {
+    private ObjectMapper objectMapper = new ServiceConfiguration("", 0, 0).createObjectMapper();
+
+    @Test
+    public void thatJsonIsDeserialized() throws IOException {
+        String json = "{\"firstName\": \"firstname\", \"lastName\": \"lastname\", \"dateOfBirth\": \"1970-01-01\", \"nino\": \"QQ123456C\"}";
+
+        HmrcIndividual individual = objectMapper.readValue(json, HmrcIndividual.class);
+
+        assertThat(individual).isNotNull();
+        assertThat(individual.nino()).isEqualTo("QQ123456C");
+        assertThat(individual.dateOfBirth()).isEqualTo(LocalDate.parse("1970-01-01"));
+        assertThat(individual.lastName()).isEqualTo("lastname");
+        assertThat(individual.firstName()).isEqualTo("firstname");
+    }
+}

--- a/src/test/java/uk/gov/digital/ho/proving/income/hmrc/domain/IncomeRecordTest.java
+++ b/src/test/java/uk/gov/digital/ho/proving/income/hmrc/domain/IncomeRecordTest.java
@@ -1,7 +1,10 @@
 package uk.gov.digital.ho.proving.income.hmrc.domain;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
 import org.junit.Test;
+import uk.gov.digital.ho.proving.income.application.ServiceConfiguration;
 
+import java.io.IOException;
 import java.math.BigDecimal;
 import java.time.LocalDate;
 import java.util.ArrayList;
@@ -56,5 +59,21 @@ public class IncomeRecordTest {
         assertThat(incomeRecord.paye().size()).isEqualTo(4);
         assertThat(deDuplicated.size()).isEqualTo(2);
         assertThat(incomeRecord.paye().containsAll(deDuplicated));
+    }
+
+    @Test
+    public void shouldDeserializeIndividual() throws IOException {
+        ObjectMapper objectMapper = new ServiceConfiguration("", 0, 0).createObjectMapper();
+
+        String json = "{\"individual\":{\"firstName\": \"firstname\", \"lastName\": \"lastname\", \"dateOfBirth\": \"1970-01-01\", \"nino\": \"QQ123456C\"}}";
+
+        IncomeRecord incomeRecord = objectMapper.readValue(json, IncomeRecord.class);
+
+
+        assertThat(incomeRecord).isNotNull();
+        assertThat(incomeRecord.individual().nino()).isEqualTo("QQ123456C");
+        assertThat(incomeRecord.individual().dateOfBirth()).isEqualTo(LocalDate.parse("1970-01-01"));
+        assertThat(incomeRecord.individual().lastName()).isEqualTo("lastname");
+        assertThat(incomeRecord.individual().firstName()).isEqualTo("firstname");
     }
 }


### PR DESCRIPTION
The HMRC API sends an "individual" property but our API expected it to
be called "hmrcIndividual" -- so it was always set to null.

Making it no longer null magically made everything start working as
designed.