### PR TITLE
EE 8038 Bug: cat a monthly validator not 6 calendar months

### DIFF
--- a/src/main/java/uk/gov/digital/ho/proving/income/validator/CatASalariedIncomeValidator.java
+++ b/src/main/java/uk/gov/digital/ho/proving/income/validator/CatASalariedIncomeValidator.java
@@ -4,8 +4,12 @@ import org.springframework.stereotype.Service;
 import uk.gov.digital.ho.proving.income.validator.domain.IncomeValidationRequest;
 import uk.gov.digital.ho.proving.income.validator.domain.IncomeValidationResult;
 
+import java.time.LocalDate;
+
 @Service
 public class CatASalariedIncomeValidator implements ActiveIncomeValidator {
+
+    static final Integer NUMBER_OF_MONTHS = 6;
 
     private IncomeValidator catASalariedMonthlyIncomeValidator;
     private IncomeValidator catASalariedWeeklyIncomeValidator;
@@ -33,5 +37,9 @@ public class CatASalariedIncomeValidator implements ActiveIncomeValidator {
                 return catAUnsupportedIncomeValidator.validate(incomeValidationRequest);
         }
 
+    }
+
+    static LocalDate getAssessmentStartDate(final LocalDate applicationRaisedDate) {
+        return applicationRaisedDate.minusMonths(NUMBER_OF_MONTHS);
     }
 }

--- a/src/main/java/uk/gov/digital/ho/proving/income/validator/CatASalariedIncomeValidator.java
+++ b/src/main/java/uk/gov/digital/ho/proving/income/validator/CatASalariedIncomeValidator.java
@@ -9,7 +9,7 @@ import java.time.LocalDate;
 @Service
 public class CatASalariedIncomeValidator implements ActiveIncomeValidator {
 
-    static final Integer NUMBER_OF_MONTHS = 6;
+    static final Integer MONTHS_OF_INCOME = 6;
 
     private IncomeValidator catASalariedMonthlyIncomeValidator;
     private IncomeValidator catASalariedWeeklyIncomeValidator;
@@ -40,6 +40,6 @@ public class CatASalariedIncomeValidator implements ActiveIncomeValidator {
     }
 
     static LocalDate getAssessmentStartDate(final LocalDate applicationRaisedDate) {
-        return applicationRaisedDate.minusMonths(NUMBER_OF_MONTHS);
+        return applicationRaisedDate.minusMonths(MONTHS_OF_INCOME);
     }
 }

--- a/src/main/java/uk/gov/digital/ho/proving/income/validator/CatASalariedMonthlyIncomeValidator.java
+++ b/src/main/java/uk/gov/digital/ho/proving/income/validator/CatASalariedMonthlyIncomeValidator.java
@@ -14,7 +14,7 @@ import java.util.List;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
-import static uk.gov.digital.ho.proving.income.validator.CatASalariedIncomeValidator.NUMBER_OF_MONTHS;
+import static uk.gov.digital.ho.proving.income.validator.CatASalariedIncomeValidator.MONTHS_OF_INCOME;
 import static uk.gov.digital.ho.proving.income.validator.CatASalariedIncomeValidator.getAssessmentStartDate;
 import static uk.gov.digital.ho.proving.income.validator.IncomeValidationHelper.*;
 
@@ -58,11 +58,11 @@ public class CatASalariedMonthlyIncomeValidator implements IncomeValidator {
 
     private IncomeValidationStatus financialCheckForMonthlySalaried(List<Income> incomes, BigDecimal threshold, LocalDate assessmentStartDate, LocalDate applicationRaisedDate) {
         Stream<Income> individualIncome = filterIncomesByDates(incomes, assessmentStartDate, applicationRaisedDate);
-        List<Income> lastXMonths = individualIncome.limit(NUMBER_OF_MONTHS).collect(Collectors.toList());
-        if (lastXMonths.size() >= NUMBER_OF_MONTHS) {
+        List<Income> lastXMonths = individualIncome.limit(MONTHS_OF_INCOME).collect(Collectors.toList());
+        if (lastXMonths.size() >= MONTHS_OF_INCOME) {
 
-            // Do we have NUMBER_OF_MONTHS consecutive months with the same employer
-            for (int i = 0; i < NUMBER_OF_MONTHS - 1; i++) {
+            // Do we have MONTHS_OF_INCOME consecutive months with the same employer
+            for (int i = 0; i < MONTHS_OF_INCOME - 1; i++) {
                 if (!isSuccessiveMonths(lastXMonths.get(i), lastXMonths.get(i + 1))) {
                     log.debug("FAILED: Months not consecutive");
                     return IncomeValidationStatus.NON_CONSECUTIVE_MONTHS;

--- a/src/main/java/uk/gov/digital/ho/proving/income/validator/CatASalariedMonthlyIncomeValidator.java
+++ b/src/main/java/uk/gov/digital/ho/proving/income/validator/CatASalariedMonthlyIncomeValidator.java
@@ -9,7 +9,7 @@ import uk.gov.digital.ho.proving.income.validator.domain.*;
 
 import java.math.BigDecimal;
 import java.time.LocalDate;
-import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
@@ -42,21 +42,20 @@ public class CatASalariedMonthlyIncomeValidator implements IncomeValidator {
         IncomeValidationStatus status =
             financialCheckForMonthlySalaried(
                 removeDuplicates(applicantIncome.incomeRecord().paye()),
-                NUMBER_OF_MONTHS,
                 monthlyThreshold,
                 assessmentStartDate,
                 incomeValidationRequest.applicationRaisedDate());
 
-        return new IncomeValidationResult(status, monthlyThreshold, Arrays.asList(checkedIndividual), assessmentStartDate, CATEGORY, CALCULATION_TYPE);
+        return new IncomeValidationResult(status, monthlyThreshold, Collections.singletonList(checkedIndividual), assessmentStartDate, CATEGORY, CALCULATION_TYPE);
     }
 
-    private IncomeValidationStatus financialCheckForMonthlySalaried(List<Income> incomes, int numOfMonths, BigDecimal threshold, LocalDate assessmentStartDate, LocalDate applicationRaisedDate) {
+    private IncomeValidationStatus financialCheckForMonthlySalaried(List<Income> incomes, BigDecimal threshold, LocalDate assessmentStartDate, LocalDate applicationRaisedDate) {
         Stream<Income> individualIncome = filterIncomesByDates(incomes, assessmentStartDate, applicationRaisedDate);
-        List<Income> lastXMonths = individualIncome.limit(numOfMonths).collect(Collectors.toList());
-        if (lastXMonths.size() >= numOfMonths) {
+        List<Income> lastXMonths = individualIncome.limit(NUMBER_OF_MONTHS).collect(Collectors.toList());
+        if (lastXMonths.size() >= NUMBER_OF_MONTHS) {
 
             // Do we have NUMBER_OF_MONTHS consecutive months with the same employer
-            for (int i = 0; i < numOfMonths - 1; i++) {
+            for (int i = 0; i < NUMBER_OF_MONTHS - 1; i++) {
                 if (!isSuccessiveMonths(lastXMonths.get(i), lastXMonths.get(i + 1))) {
                     log.debug("FAILED: Months not consecutive");
                     return IncomeValidationStatus.NON_CONSECUTIVE_MONTHS;

--- a/src/main/java/uk/gov/digital/ho/proving/income/validator/CatASalariedMonthlyIncomeValidator.java
+++ b/src/main/java/uk/gov/digital/ho/proving/income/validator/CatASalariedMonthlyIncomeValidator.java
@@ -14,14 +14,14 @@ import java.util.List;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
+import static uk.gov.digital.ho.proving.income.validator.CatASalariedIncomeValidator.NUMBER_OF_MONTHS;
+import static uk.gov.digital.ho.proving.income.validator.CatASalariedIncomeValidator.getAssessmentStartDate;
 import static uk.gov.digital.ho.proving.income.validator.IncomeValidationHelper.*;
 
 @Slf4j
 @Service
 public class CatASalariedMonthlyIncomeValidator implements IncomeValidator {
 
-    private static final Integer ASSESSMENT_START_DAYS_PREVIOUS = 182;
-    private static final Integer NUMBER_OF_MONTHS = 6;
     private static final String CALCULATION_TYPE = "Category A Monthly Salary";
     private static final String CATEGORY = "A";
 
@@ -37,7 +37,7 @@ public class CatASalariedMonthlyIncomeValidator implements IncomeValidator {
         IncomeThresholdCalculator thresholdCalculator = new IncomeThresholdCalculator(incomeValidationRequest.dependants());
         BigDecimal monthlyThreshold = thresholdCalculator.getMonthlyThreshold();
 
-        LocalDate assessmentStartDate = incomeValidationRequest.applicationRaisedDate().minusDays(ASSESSMENT_START_DAYS_PREVIOUS);
+        LocalDate assessmentStartDate = getAssessmentStartDate(incomeValidationRequest.applicationRaisedDate());
 
         IncomeValidationStatus status =
             financialCheckForMonthlySalaried(

--- a/src/main/java/uk/gov/digital/ho/proving/income/validator/CatASalariedWeeklyIncomeValidator.java
+++ b/src/main/java/uk/gov/digital/ho/proving/income/validator/CatASalariedWeeklyIncomeValidator.java
@@ -19,7 +19,7 @@ import static uk.gov.digital.ho.proving.income.validator.IncomeValidationHelper.
 @Service
 public class CatASalariedWeeklyIncomeValidator implements IncomeValidator {
 
-    private final static Integer NUMBER_OF_WEEKS = 26;
+    private final static Integer WEEKS_OF_INCOME = 26;
     private static final String CALCULATION_TYPE = "Category A Weekly Salary";
     private static final String CATEGORY = "A";
 
@@ -58,7 +58,7 @@ public class CatASalariedWeeklyIncomeValidator implements IncomeValidator {
         Stream<Income> individualIncome = filterIncomesByDates(incomes, assessmentStartDate, applicationRaisedDate);
         List<Income> lastXWeeks = individualIncome.collect(Collectors.toList());
 
-        if (lastXWeeks.size() >= NUMBER_OF_WEEKS) {
+        if (lastXWeeks.size() >= WEEKS_OF_INCOME) {
             EmploymentCheck employmentCheck = checkIncomesPassThresholdWithSameEmployer(lastXWeeks, threshold);
             if (employmentCheck.equals(EmploymentCheck.PASS)) {
                 return IncomeValidationStatus.WEEKLY_SALARIED_PASSED;

--- a/src/main/java/uk/gov/digital/ho/proving/income/validator/CatASalariedWeeklyIncomeValidator.java
+++ b/src/main/java/uk/gov/digital/ho/proving/income/validator/CatASalariedWeeklyIncomeValidator.java
@@ -13,12 +13,12 @@ import java.util.List;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
+import static uk.gov.digital.ho.proving.income.validator.CatASalariedIncomeValidator.getAssessmentStartDate;
 import static uk.gov.digital.ho.proving.income.validator.IncomeValidationHelper.*;
 
 @Service
 public class CatASalariedWeeklyIncomeValidator implements IncomeValidator {
 
-    private static final Integer ASSESSMENT_START_DAYS_PREVIOUS = 182;
     private final static Integer NUMBER_OF_WEEKS = 26;
     private static final String CALCULATION_TYPE = "Category A Weekly Salary";
     private static final String CATEGORY = "A";
@@ -35,7 +35,7 @@ public class CatASalariedWeeklyIncomeValidator implements IncomeValidator {
         IncomeThresholdCalculator thresholdCalculator = new IncomeThresholdCalculator(incomeValidationRequest.dependants());
         BigDecimal weeklyThreshold = thresholdCalculator.getWeeklyThreshold();
 
-        LocalDate assessmentStartDate = incomeValidationRequest.applicationRaisedDate().minusDays(ASSESSMENT_START_DAYS_PREVIOUS);
+        LocalDate assessmentStartDate = getAssessmentStartDate(incomeValidationRequest.applicationRaisedDate());
 
         IncomeValidationStatus status =
             financialCheckForWeeklySalaried(

--- a/src/main/java/uk/gov/digital/ho/proving/income/validator/CatASalariedWeeklyIncomeValidator.java
+++ b/src/main/java/uk/gov/digital/ho/proving/income/validator/CatASalariedWeeklyIncomeValidator.java
@@ -8,7 +8,7 @@ import uk.gov.digital.ho.proving.income.validator.domain.*;
 
 import java.math.BigDecimal;
 import java.time.LocalDate;
-import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
@@ -40,19 +40,18 @@ public class CatASalariedWeeklyIncomeValidator implements IncomeValidator {
         IncomeValidationStatus status =
             financialCheckForWeeklySalaried(
                 removeDuplicates(applicantIncome.incomeRecord().paye()),
-                NUMBER_OF_WEEKS,
                 weeklyThreshold,
                 assessmentStartDate,
                 incomeValidationRequest.applicationRaisedDate());
 
-        return new IncomeValidationResult(status, weeklyThreshold, Arrays.asList(checkedIndividual), assessmentStartDate, CATEGORY, CALCULATION_TYPE);
+        return new IncomeValidationResult(status, weeklyThreshold, Collections.singletonList(checkedIndividual), assessmentStartDate, CATEGORY, CALCULATION_TYPE);
     }
 
-    private static IncomeValidationStatus financialCheckForWeeklySalaried(List<Income> incomes, int numOfWeeks, BigDecimal threshold, LocalDate assessmentStartDate, LocalDate applicationRaisedDate) {
+    private static IncomeValidationStatus financialCheckForWeeklySalaried(List<Income> incomes, BigDecimal threshold, LocalDate assessmentStartDate, LocalDate applicationRaisedDate) {
         Stream<Income> individualIncome = filterIncomesByDates(incomes, assessmentStartDate, applicationRaisedDate);
         List<Income> lastXWeeks = individualIncome.collect(Collectors.toList());
 
-        if (lastXWeeks.size() >= numOfWeeks) {
+        if (lastXWeeks.size() >= NUMBER_OF_WEEKS) {
             EmploymentCheck employmentCheck = checkIncomesPassThresholdWithSameEmployer(lastXWeeks, threshold);
             if (employmentCheck.equals(EmploymentCheck.PASS)) {
                 return IncomeValidationStatus.WEEKLY_SALARIED_PASSED;

--- a/src/main/java/uk/gov/digital/ho/proving/income/validator/CatAUnsupportedIncomeValidator.java
+++ b/src/main/java/uk/gov/digital/ho/proving/income/validator/CatAUnsupportedIncomeValidator.java
@@ -8,7 +8,6 @@ import uk.gov.digital.ho.proving.income.validator.domain.IncomeValidationResult;
 import uk.gov.digital.ho.proving.income.validator.domain.IncomeValidationStatus;
 
 import java.math.BigDecimal;
-import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 

--- a/src/main/java/uk/gov/digital/ho/proving/income/validator/CatAUnsupportedIncomeValidator.java
+++ b/src/main/java/uk/gov/digital/ho/proving/income/validator/CatAUnsupportedIncomeValidator.java
@@ -12,12 +12,12 @@ import java.math.BigDecimal;
 import java.util.Arrays;
 import java.util.List;
 
+import static uk.gov.digital.ho.proving.income.validator.CatASalariedIncomeValidator.getAssessmentStartDate;
 import static uk.gov.digital.ho.proving.income.validator.IncomeValidationHelper.toEmployerNames;
 
 @Service
 public class CatAUnsupportedIncomeValidator implements IncomeValidator {
 
-    private static final Integer ASSESSMENT_START_DAYS_PREVIOUS = 182;
     private static final String CALCULATION_TYPE = "Category A Unsupported Salary Frequency";
     private static final String CATEGORY = "A";
 
@@ -27,7 +27,7 @@ public class CatAUnsupportedIncomeValidator implements IncomeValidator {
         FrequencyCalculator.Frequency frequency = FrequencyCalculator.calculate(applicantIncome.incomeRecord());
         List<String> employments = toEmployerNames(applicantIncome.employments());
         CheckedIndividual checkedIndividual = new CheckedIndividual(applicantIncome.applicant().nino(), employments);
-        return new IncomeValidationResult(getStatus(frequency), BigDecimal.ZERO, Arrays.asList(checkedIndividual), incomeValidationRequest.applicationRaisedDate().minusDays(ASSESSMENT_START_DAYS_PREVIOUS), CATEGORY, CALCULATION_TYPE);
+        return new IncomeValidationResult(getStatus(frequency), BigDecimal.ZERO, Arrays.asList(checkedIndividual), getAssessmentStartDate(incomeValidationRequest.applicationRaisedDate()), CATEGORY, CALCULATION_TYPE);
     }
 
     private IncomeValidationStatus getStatus(FrequencyCalculator.Frequency frequency) {

--- a/src/main/java/uk/gov/digital/ho/proving/income/validator/CatAUnsupportedIncomeValidator.java
+++ b/src/main/java/uk/gov/digital/ho/proving/income/validator/CatAUnsupportedIncomeValidator.java
@@ -1,6 +1,5 @@
 package uk.gov.digital.ho.proving.income.validator;
 
-import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.stereotype.Service;
 import uk.gov.digital.ho.proving.income.api.domain.CheckedIndividual;
 import uk.gov.digital.ho.proving.income.validator.domain.ApplicantIncome;
@@ -10,6 +9,7 @@ import uk.gov.digital.ho.proving.income.validator.domain.IncomeValidationStatus;
 
 import java.math.BigDecimal;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
 
 import static uk.gov.digital.ho.proving.income.validator.CatASalariedIncomeValidator.getAssessmentStartDate;
@@ -27,7 +27,7 @@ public class CatAUnsupportedIncomeValidator implements IncomeValidator {
         FrequencyCalculator.Frequency frequency = FrequencyCalculator.calculate(applicantIncome.incomeRecord());
         List<String> employments = toEmployerNames(applicantIncome.employments());
         CheckedIndividual checkedIndividual = new CheckedIndividual(applicantIncome.applicant().nino(), employments);
-        return new IncomeValidationResult(getStatus(frequency), BigDecimal.ZERO, Arrays.asList(checkedIndividual), getAssessmentStartDate(incomeValidationRequest.applicationRaisedDate()), CATEGORY, CALCULATION_TYPE);
+        return new IncomeValidationResult(getStatus(frequency), BigDecimal.ZERO, Collections.singletonList(checkedIndividual), getAssessmentStartDate(incomeValidationRequest.applicationRaisedDate()), CATEGORY, CALCULATION_TYPE);
     }
 
     private IncomeValidationStatus getStatus(FrequencyCalculator.Frequency frequency) {

--- a/src/test/java/apidocs/v1/ApiDocumentation.java
+++ b/src/test/java/apidocs/v1/ApiDocumentation.java
@@ -93,7 +93,7 @@ public class ApiDocumentation {
         fieldWithPath("categoryCheck.category").description("The category that was checked"),
         fieldWithPath("categoryCheck.passed").description("True if this individual meets the financial status requirements for the given Category, otherwise false"),
         fieldWithPath("categoryCheck.applicationRaisedDate").description("Date of the application"),
-        fieldWithPath("categoryCheck.assessmentStartDate").description("Start date of the financial status check based on the application raised date minus 182 days"),
+        fieldWithPath("categoryCheck.assessmentStartDate").description("Start date of the financial status check based on the application raised date minus 6 months"),
         fieldWithPath("categoryCheck.failureReason").description("Description of the failure reason when passed is not true - see <<Glossary>>"),
         fieldWithPath("categoryCheck.threshold").description("Calculated threshold required for a pass"),
         fieldWithPath("categoryCheck.employers").description("Employer names returned by HMRC")

--- a/src/test/java/uk/gov/digital/ho/proving/income/validator/CatAMonthlyIncomeValidatorTestToo.java
+++ b/src/test/java/uk/gov/digital/ho/proving/income/validator/CatAMonthlyIncomeValidatorTestToo.java
@@ -130,7 +130,7 @@ public class CatAMonthlyIncomeValidatorTestToo {
     }
 
     @Test
-    @Ignore("EE-8087") // TODO 2018/09/04 Date-related test failure; either a bug to fix or test to be updated; skipped until decision made.
+    @Ignore("EE-8038") // TODO 2018/09/04 Date-related test failure; either a bug to fix or test to be updated; skipped until decision made.
     public void shouldPassWhenValidWithoutDuplicatesAndDayInMonthOfPaymentAfterCurrentDayOfMonth() {
 
         HmrcIndividual hmrcIndividual = aIndividual();
@@ -146,7 +146,7 @@ public class CatAMonthlyIncomeValidatorTestToo {
     }
 
     @Test
-    @Ignore("EE-8087") // TODO 2018/09/04 Date-related test failure; either a bug to fix or test to be updated; skipped until decision made.
+    @Ignore("EE-8038") // TODO 2018/09/04 Date-related test failure; either a bug to fix or test to be updated; skipped until decision made.
     public void shouldPassWhenValidWithDuplicates() {
 
         HmrcIndividual hmrcIndividual = aIndividual();

--- a/src/test/java/uk/gov/digital/ho/proving/income/validator/CatAMonthlyIncomeValidatorTestToo.java
+++ b/src/test/java/uk/gov/digital/ho/proving/income/validator/CatAMonthlyIncomeValidatorTestToo.java
@@ -2,7 +2,6 @@ package uk.gov.digital.ho.proving.income.validator;
 
 import com.google.common.collect.ImmutableList;
 import org.junit.Before;
-import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.runners.MockitoJUnitRunner;
@@ -192,55 +191,6 @@ public class CatAMonthlyIncomeValidatorTestToo {
         IncomeValidationResult result = service.validate(request);
 
         assertThat(result.individuals().get(0).employers().size()).isEqualTo(2);
-    }
-
-    @Test
-    public void testAssessmentStartDate6MonthsAgo() {
-        List<Income> incomes = new ArrayList<>();
-        HmrcIndividual hmrcIndividual = aIndividual();
-        Applicant applicant = new Applicant(hmrcIndividual.firstName(), hmrcIndividual.lastName(), LocalDate.now(), hmrcIndividual.nino());
-        IncomeRecord incomeRecord = new IncomeRecord(incomes, taxReturns, employments, hmrcIndividual);
-        ApplicantIncome applicantIncome = new ApplicantIncome(applicant, incomeRecord);
-
-        LocalDate applicationRaisedDate = LocalDate.of(2018, 7, 14);
-        IncomeValidationRequest request = new IncomeValidationRequest(ImmutableList.of(applicantIncome), applicationRaisedDate, 0);
-
-        IncomeValidationResult result = service.validate(request);
-
-        assertThat(result.assessmentStartDate()).isEqualTo(LocalDate.of(2018, 1, 14));
-    }
-
-    @Test
-    public void testAssessmentStartDate6MonthsAgo31stAugust() {
-        List<Income> incomes = new ArrayList<>();
-        HmrcIndividual hmrcIndividual = aIndividual();
-        Applicant applicant = new Applicant(hmrcIndividual.firstName(), hmrcIndividual.lastName(), LocalDate.now(), hmrcIndividual.nino());
-        IncomeRecord incomeRecord = new IncomeRecord(incomes, taxReturns, employments, hmrcIndividual);
-        ApplicantIncome applicantIncome = new ApplicantIncome(applicant, incomeRecord);
-
-        LocalDate applicationRaisedDate = LocalDate.of(2018, 8, 31);
-        IncomeValidationRequest request = new IncomeValidationRequest(ImmutableList.of(applicantIncome), applicationRaisedDate, 0);
-
-        IncomeValidationResult result = service.validate(request);
-
-        assertThat(result.assessmentStartDate()).isEqualTo(LocalDate.of(2018, 2, 28));
-    }
-
-    @Test
-    public void testAssessmentStartDate6MonthsAgo31stAugustLeapYear() {
-        List<Income> incomes = new ArrayList<>();
-        HmrcIndividual hmrcIndividual = aIndividual();
-        Applicant applicant = new Applicant(hmrcIndividual.firstName(), hmrcIndividual.lastName(), LocalDate.now(), hmrcIndividual.nino());
-        IncomeRecord incomeRecord = new IncomeRecord(incomes, taxReturns, employments, hmrcIndividual);
-        ApplicantIncome applicantIncome = new ApplicantIncome(applicant, incomeRecord);
-
-        LocalDate applicationRaisedDate = LocalDate.of(2020, 8, 31);
-        IncomeValidationRequest request = new IncomeValidationRequest(ImmutableList.of(applicantIncome), applicationRaisedDate, 0);
-
-        IncomeValidationResult result = service.validate(request);
-
-        assertThat(result.assessmentStartDate()).isEqualTo(LocalDate.of(2020, 2, 29));
-
     }
 
     private HmrcIndividual aIndividual() {

--- a/src/test/java/uk/gov/digital/ho/proving/income/validator/CatAMonthlyIncomeValidatorTestToo.java
+++ b/src/test/java/uk/gov/digital/ho/proving/income/validator/CatAMonthlyIncomeValidatorTestToo.java
@@ -130,7 +130,6 @@ public class CatAMonthlyIncomeValidatorTestToo {
     }
 
     @Test
-    @Ignore("EE-8038") // TODO 2018/09/04 Date-related test failure; either a bug to fix or test to be updated; skipped until decision made.
     public void shouldPassWhenValidWithoutDuplicatesAndDayInMonthOfPaymentAfterCurrentDayOfMonth() {
 
         HmrcIndividual hmrcIndividual = aIndividual();
@@ -146,7 +145,6 @@ public class CatAMonthlyIncomeValidatorTestToo {
     }
 
     @Test
-    @Ignore("EE-8038") // TODO 2018/09/04 Date-related test failure; either a bug to fix or test to be updated; skipped until decision made.
     public void shouldPassWhenValidWithDuplicates() {
 
         HmrcIndividual hmrcIndividual = aIndividual();
@@ -194,6 +192,55 @@ public class CatAMonthlyIncomeValidatorTestToo {
         IncomeValidationResult result = service.validate(request);
 
         assertThat(result.individuals().get(0).employers().size()).isEqualTo(2);
+    }
+
+    @Test
+    public void testAssessmentStartDate6MonthsAgo() {
+        List<Income> incomes = new ArrayList<>();
+        HmrcIndividual hmrcIndividual = aIndividual();
+        Applicant applicant = new Applicant(hmrcIndividual.firstName(), hmrcIndividual.lastName(), LocalDate.now(), hmrcIndividual.nino());
+        IncomeRecord incomeRecord = new IncomeRecord(incomes, taxReturns, employments, hmrcIndividual);
+        ApplicantIncome applicantIncome = new ApplicantIncome(applicant, incomeRecord);
+
+        LocalDate applicationRaisedDate = LocalDate.of(2018, 7, 14);
+        IncomeValidationRequest request = new IncomeValidationRequest(ImmutableList.of(applicantIncome), applicationRaisedDate, 0);
+
+        IncomeValidationResult result = service.validate(request);
+
+        assertThat(result.assessmentStartDate()).isEqualTo(LocalDate.of(2018, 1, 14));
+    }
+
+    @Test
+    public void testAssessmentStartDate6MonthsAgo31stAugust() {
+        List<Income> incomes = new ArrayList<>();
+        HmrcIndividual hmrcIndividual = aIndividual();
+        Applicant applicant = new Applicant(hmrcIndividual.firstName(), hmrcIndividual.lastName(), LocalDate.now(), hmrcIndividual.nino());
+        IncomeRecord incomeRecord = new IncomeRecord(incomes, taxReturns, employments, hmrcIndividual);
+        ApplicantIncome applicantIncome = new ApplicantIncome(applicant, incomeRecord);
+
+        LocalDate applicationRaisedDate = LocalDate.of(2018, 8, 31);
+        IncomeValidationRequest request = new IncomeValidationRequest(ImmutableList.of(applicantIncome), applicationRaisedDate, 0);
+
+        IncomeValidationResult result = service.validate(request);
+
+        assertThat(result.assessmentStartDate()).isEqualTo(LocalDate.of(2018, 2, 28));
+    }
+
+    @Test
+    public void testAssessmentStartDate6MonthsAgo31stAugustLeapYear() {
+        List<Income> incomes = new ArrayList<>();
+        HmrcIndividual hmrcIndividual = aIndividual();
+        Applicant applicant = new Applicant(hmrcIndividual.firstName(), hmrcIndividual.lastName(), LocalDate.now(), hmrcIndividual.nino());
+        IncomeRecord incomeRecord = new IncomeRecord(incomes, taxReturns, employments, hmrcIndividual);
+        ApplicantIncome applicantIncome = new ApplicantIncome(applicant, incomeRecord);
+
+        LocalDate applicationRaisedDate = LocalDate.of(2020, 8, 31);
+        IncomeValidationRequest request = new IncomeValidationRequest(ImmutableList.of(applicantIncome), applicationRaisedDate, 0);
+
+        IncomeValidationResult result = service.validate(request);
+
+        assertThat(result.assessmentStartDate()).isEqualTo(LocalDate.of(2020, 2, 29));
+
     }
 
     private HmrcIndividual aIndividual() {

--- a/src/test/java/uk/gov/digital/ho/proving/income/validator/CatAMonthlyIncomeValidatorTestToo.java
+++ b/src/test/java/uk/gov/digital/ho/proving/income/validator/CatAMonthlyIncomeValidatorTestToo.java
@@ -2,6 +2,7 @@ package uk.gov.digital.ho.proving.income.validator;
 
 import com.google.common.collect.ImmutableList;
 import org.junit.Before;
+import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.runners.MockitoJUnitRunner;
@@ -129,6 +130,7 @@ public class CatAMonthlyIncomeValidatorTestToo {
     }
 
     @Test
+    @Ignore("EE-8087") // TODO 2018/09/04 Date-related test failure; either a bug to fix or test to be updated; skipped until decision made.
     public void shouldPassWhenValidWithoutDuplicatesAndDayInMonthOfPaymentAfterCurrentDayOfMonth() {
 
         HmrcIndividual hmrcIndividual = aIndividual();
@@ -144,6 +146,7 @@ public class CatAMonthlyIncomeValidatorTestToo {
     }
 
     @Test
+    @Ignore("EE-8087") // TODO 2018/09/04 Date-related test failure; either a bug to fix or test to be updated; skipped until decision made.
     public void shouldPassWhenValidWithDuplicates() {
 
         HmrcIndividual hmrcIndividual = aIndividual();

--- a/src/test/java/uk/gov/digital/ho/proving/income/validator/CatASalariedIncomeValidatorTest.java
+++ b/src/test/java/uk/gov/digital/ho/proving/income/validator/CatASalariedIncomeValidatorTest.java
@@ -17,8 +17,10 @@ import java.time.Month;
 import java.util.ArrayList;
 import java.util.List;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Matchers.any;
 import static org.mockito.Mockito.*;
+import static uk.gov.digital.ho.proving.income.validator.CatASalariedIncomeValidator.getAssessmentStartDate;
 import static uk.gov.digital.ho.proving.income.validator.CatASalariedTestData.*;
 
 @RunWith(MockitoJUnitRunner.class)
@@ -90,5 +92,21 @@ public class CatASalariedIncomeValidatorTest {
         verify(unsupportedValidator).validate(request);
     }
 
+    @Test
+    public void getAssessmentStartDateShouldBe6MonthsAgo() {
+        LocalDate applicationRaisedDate = LocalDate.of(2018, Month.SEPTEMBER, 6);
+        assertThat(getAssessmentStartDate(applicationRaisedDate)).isEqualTo(LocalDate.of(2018, Month.MARCH, 6));
+    }
 
+    @Test
+    public void getAssessmentStartDateShouldBe6MonthsAgoAugust31st() {
+        LocalDate applicationRaisedDate = LocalDate.of(2018, Month.AUGUST, 31);
+        assertThat(getAssessmentStartDate(applicationRaisedDate)).isEqualTo(LocalDate.of(2018, Month.FEBRUARY, 28));
+    }
+
+    @Test
+    public void getAssessmentStartDateShouldBe6MonthsAgoAugust31stLeapYear() {
+        LocalDate applicationRaisedDate = LocalDate.of(2020, Month.AUGUST, 31);
+        assertThat(getAssessmentStartDate(applicationRaisedDate)).isEqualTo(LocalDate.of(2020, Month.FEBRUARY, 29));
+    }
 }

--- a/src/test/specs/API-v2/TMFM1_Failure - Category A Financial Requirement (with dependents - monthly pay).feature
+++ b/src/test/specs/API-v2/TMFM1_Failure - Category A Financial Requirement (with dependents - monthly pay).feature
@@ -1,7 +1,7 @@
 Feature: Failure - Category A Financial Requirement - with dependents - monthly pay
 
     Requirement to meet Category A
-    Applicant or Sponsor has received < 6 consecutive monthly payments from the same employer over the 182 day period prior to the Application Raised Date
+    Applicant or Sponsor has received < 6 consecutive monthly payments from the same employer over the 6 month period prior to the Application Raised Date
 
     Financial income regulation to pass this Feature File
     Income required Amount no Dependent Child = £18600 (£1550 per month or above)
@@ -9,7 +9,7 @@ Feature: Failure - Category A Financial Requirement - with dependents - monthly 
     Additional funds for EVERY subsequent dependent child = £2400 on top of employment threshold per child
 
     Financial income calculation to pass this Feature File
-    Income required amount + 1 dependant amount + (Additional dependant amount * number of dependants)/12 = Gross Monthly Income is < Threshold in any one of the 6 payments in the 182 days prior to the Application Raised Date
+    Income required amount + 1 dependant amount + (Additional dependant amount * number of dependants)/12 = Gross Monthly Income is < Threshold in any one of the 6 payments in the 6 months prior to the Application Raised Date
 
     1 Dependent Child - £18600+£3800/12 = £1866.67
     2 Dependent Children - £18600+£3800+£2400/12 = £2066.67
@@ -47,7 +47,7 @@ Feature: Failure - Category A Financial Requirement - with dependents - monthly 
             | Applicant                 | National Insurance Number | SP123456B                     |
             | Category A Monthly Salary | Financial requirement met | false                         |
             | Category A Monthly Salary | Failure reason            | MONTHLY_VALUE_BELOW_THRESHOLD |
-            | Category A Monthly Salary | Assessment start date     | 2014-08-05                    |
+            | Category A Monthly Salary | Assessment start date     | 2014-08-03                    |
             | Category A Monthly Salary | Application Raised date   | 2015-02-03                    |
             | Category A Monthly Salary | Threshold                 | 2466.67                       |
             | Category A Monthly Salary | Employer Name - SP123456B | Flying Pizza Ltd              |
@@ -79,7 +79,7 @@ Feature: Failure - Category A Financial Requirement - with dependents - monthly 
             | Applicant                 | National Insurance Number | BS123456B                     |
             | Category A Monthly Salary | Financial requirement met | false                         |
             | Category A Monthly Salary | Failure reason            | MONTHLY_VALUE_BELOW_THRESHOLD |
-            | Category A Monthly Salary | Assessment start date     | 2014-08-12                    |
+            | Category A Monthly Salary | Assessment start date     | 2014-08-10                    |
             | Category A Monthly Salary | Application Raised date   | 2015-02-10                    |
             | Category A Monthly Salary | Threshold                 | 2066.67                       |
             | Category A Monthly Salary | Employer Name - BS123456B | Flying Pizza Ltd              |
@@ -113,7 +113,7 @@ Feature: Failure - Category A Financial Requirement - with dependents - monthly 
             | Applicant                 | National Insurance Number | SY987654C                 |
             | Category A Monthly Salary | Financial requirement met | false                     |
             | Category A Monthly Salary | Failure reason            | MULTIPLE_EMPLOYERS        |
-            | Category A Monthly Salary | Assessment start date     | 2015-03-05                |
+            | Category A Monthly Salary | Assessment start date     | 2015-03-03                |
             | Category A Monthly Salary | Application Raised date   | 2015-09-03                |
             | Category A Monthly Salary | Threshold                 | 2266.67                   |
             | Category A Monthly Salary | Employer Name - SY987654C | Flying Pizza Ltd , FLying |
@@ -147,7 +147,7 @@ Feature: Failure - Category A Financial Requirement - with dependents - monthly 
             | Applicant                 | National Insurance Number | SY987654C          |
             | Category A Monthly Salary | Financial requirement met | false              |
             | Category A Monthly Salary | Failure reason            | NOT_ENOUGH_RECORDS |
-            | Category A Monthly Salary | Assessment start date     | 2015-03-05         |
+            | Category A Monthly Salary | Assessment start date     | 2015-03-03         |
             | Category A Monthly Salary | Application Raised date   | 2015-09-03         |
             | Category A Monthly Salary | Threshold                 | 2266.67            |
             | Category A Monthly Salary | Employer Name - SY987654C | Flying Pizza Ltd   |

--- a/src/test/specs/API-v2/TMFM2_Failure - Category A Financial Requirement (with dependents - weekly pay).feature
+++ b/src/test/specs/API-v2/TMFM2_Failure - Category A Financial Requirement (with dependents - weekly pay).feature
@@ -1,7 +1,7 @@
 Feature: Failure - Category A Financial Requirement  - with Dependants - weekly pay
 
     Requirement to meet Category A
-    Applicant or Sponsor has received < 26 payments from the same employer over 182 day period prior to the Application Raised Date
+    Applicant or Sponsor has received < 26 payments from the same employer over 6 month period prior to the Application Raised Date
 
     Financial income regulation to pass this Feature File
     Income required amount no dependant child = £18600 (£1550 per month or above for EACH of the previous 6 months from the Application Raised Date)
@@ -9,7 +9,7 @@ Feature: Failure - Category A Financial Requirement  - with Dependants - weekly 
     Additional funds for EVERY subsequent dependant child = £2400 on top of employment threshold per child
 
     Financial income calculation to pass this Feature File
-    Income required amount + 1 dependant amount + (Additional dependant amount * number of dependants)/52 weeks in the year = 26 Weekly Gross Income payments < threshold in the 182 day period prior to the Application Raised Date from the same employer
+    Income required amount + 1 dependant amount + (Additional dependant amount * number of dependants)/52 weeks in the year = 26 Weekly Gross Income payments < threshold in the 6 month period prior to the Application Raised Date from the same employer
 
     1 Dependant child - £18600+£3800/52 = £430.77
     2 Dependant children - £18600+£3800+£2400/12 = £476.92
@@ -23,7 +23,7 @@ Feature: Failure - Category A Financial Requirement  - with Dependants - weekly 
     Pay date - Weekly (variable dates)
     Before day of Application Raised Date
     He has 3 columbian dependants
-    He has received 26 Weekly Gross Income payments of £225.40 in the 182 day period from the same employer
+    He has received 26 Weekly Gross Income payments of £225.40 in the 6 month period from the same employer
 
         Given HMRC has the following income records:
             | Date       | Amount | Week Number | Month Number | PAYE Reference | Employer         |
@@ -67,7 +67,7 @@ Feature: Failure - Category A Financial Requirement  - with Dependants - weekly 
             | Applicant                | National Insurance Number | AP123456C                    |
             | Category A Weekly Salary | Financial requirement met | false                        |
             | Category A Weekly Salary | Failure reason            | WEEKLY_VALUE_BELOW_THRESHOLD |
-            | Category A Weekly Salary | Assessment start date     | 2015-05-05                   |
+            | Category A Weekly Salary | Assessment start date     | 2015-05-03                   |
             | Category A Weekly Salary | Application Raised date   | 2015-11-03                   |
             | Category A Weekly Salary | Threshold                 | 523.08                       |
             | Category A Weekly Salary | Employer Name - AP123456C | Flying Pizza Ltd             |
@@ -77,7 +77,7 @@ Feature: Failure - Category A Financial Requirement  - with Dependants - weekly 
     Scenario: John Lister does not meet the Category A Financial Requirement (He has earned < the Cat A financial threshold also does not have enough records)
 
     He has 2 Chinese dependants
-    He has received 23 Weekly Gross Income payments of £475.67 in the 182 day period from the same employer
+    He has received 23 Weekly Gross Income payments of £475.67 in the 6 month period from the same employer
 
         Given HMRC has the following income records:
             | Date       | Amount | Week Number | Month Number | PAYE Reference | Employer         |
@@ -116,7 +116,7 @@ Feature: Failure - Category A Financial Requirement  - with Dependants - weekly 
             | Applicant                | National Insurance Number | JL123456D          |
             | Category A Weekly Salary | Financial requirement met | false              |
             | Category A Weekly Salary | Failure reason            | NOT_ENOUGH_RECORDS |
-            | Category A Weekly Salary | Assessment start date     | 2015-05-05         |
+            | Category A Weekly Salary | Assessment start date     | 2015-05-03         |
             | Category A Weekly Salary | Application Raised date   | 2015-11-03         |
             | Category A Weekly Salary | Threshold                 | 476.92             |
             | Category A Weekly Salary | Employer Name - JL123456D | Flying Pizza Ltd   |
@@ -125,7 +125,7 @@ Feature: Failure - Category A Financial Requirement  - with Dependants - weekly 
     Scenario: Gary Goldstein does not meet the Category A employment duration Requirement (He has worked for his current employer for only 20 weeks)
 
     He has 3 Isreali dependants
-    He has received 20 Weekly Gross Income payments of £530.67 and 6 Weekly Gross payments of £525.30 in the 182 day period from two employers
+    He has received 20 Weekly Gross Income payments of £530.67 and 6 Weekly Gross payments of £525.30 in the 6 month period from two employers
     He worked for a different employer before his current employer
 
         Given HMRC has the following income records:
@@ -167,7 +167,7 @@ Feature: Failure - Category A Financial Requirement  - with Dependants - weekly 
             | Applicant                | National Insurance Number | GG987654A                         |
             | Category A Weekly Salary | Financial requirement met | false                             |
             | Category A Weekly Salary | Failure reason            | MULTIPLE_EMPLOYERS                |
-            | Category A Weekly Salary | Assessment start date     | 2015-03-05                        |
+            | Category A Weekly Salary | Assessment start date     | 2015-03-03                        |
             | Category A Weekly Salary | Application Raised date   | 2015-09-03                        |
             | Category A Weekly Salary | Threshold                 | 523.08                            |
             | Category A Weekly Salary | Employer Name - GG987654A | Flying Pizza Ltd, Curry House Ltd |
@@ -176,7 +176,7 @@ Feature: Failure - Category A Financial Requirement  - with Dependants - weekly 
     Scenario: Terry Pilchard does not meet the Category A Employment Requirement (He currently works for two employers)
 
     He has 3 Isreali dependants
-    He has received 26 Weekly Gross Income payments of £260.60 and £300.00 in the 182 day period from two active employers.
+    He has received 26 Weekly Gross Income payments of £260.60 and £300.00 in the 6 month period from two active employers.
     Combined the totals are above the threshold, however this will trigger a failed result.
 
         Given HMRC has the following income records:
@@ -244,7 +244,7 @@ Feature: Failure - Category A Financial Requirement  - with Dependants - weekly 
             | Applicant                | National Insurance Number | GG987654A                         |
             | Category A Weekly Salary | Financial requirement met | false                             |
             | Category A Weekly Salary | Failure reason            | WEEKLY_VALUE_BELOW_THRESHOLD      |
-            | Category A Weekly Salary | Assessment start date     | 2015-03-05                        |
+            | Category A Weekly Salary | Assessment start date     | 2015-03-03                        |
             | Category A Weekly Salary | Application Raised date   | 2015-09-03                        |
             | Category A Weekly Salary | Threshold                 | 523.08                            |
             | Category A Weekly Salary | Employer Name - GG987654A | Curry House Ltd, Flying Pizza Ltd |
@@ -285,7 +285,7 @@ Feature: Failure - Category A Financial Requirement  - with Dependants - weekly 
             | Applicant                               | National Insurance Number | JW984624A            |
             | Category A Unsupported Salary Frequency | Financial requirement met | false                |
             | Category A Unsupported Salary Frequency | Failure reason            | PAY_FREQUENCY_CHANGE |
-            | Category A Unsupported Salary Frequency | Assessment start date     | 2015-05-24           |
+            | Category A Unsupported Salary Frequency | Assessment start date     | 2015-05-22           |
             | Category A Unsupported Salary Frequency | Application Raised date   | 2015-11-22           |
             | Category A Unsupported Salary Frequency | Threshold                 | 0                    |
             | Category A Unsupported Salary Frequency | Employer Name - JW984624A | Flying Pizza Ltd     |
@@ -311,5 +311,5 @@ Feature: Failure - Category A Financial Requirement  - with Dependants - weekly 
             | Applicant                 | National Insurance Number | JL123456A          |
             | Category A Monthly Salary | Financial requirement met | false              |
             | Category A Monthly Salary | Failure reason            | NOT_ENOUGH_RECORDS |
-            | Category A Monthly Salary | Assessment start date     | 2014-07-17         |
+            | Category A Monthly Salary | Assessment start date     | 2014-07-15         |
             | Category A Monthly Salary | Application Raised date   | 2015-01-15         |

--- a/src/test/specs/API-v2/TMFM3_Failure - Category A Financial Requirement (with no dependents - monthly pay).feature
+++ b/src/test/specs/API-v2/TMFM3_Failure - Category A Financial Requirement (with no dependents - monthly pay).feature
@@ -1,10 +1,10 @@
 Feature: Failure - Category A Financial Requirement - with no dependents - monthly pay
 
     Requirement to meet Category A
-    Applicant or Sponsor has received < 6 consecutive monthly payments from the same employer over the 182 day period prior to the Application Raised Date
+    Applicant or Sponsor has received < 6 consecutive monthly payments from the same employer over the 6 month period prior to the Application Raised Date
 
     Financial employment income regulation to pass this Feature File
-    Gross Monthly Income is < £1550.00 in any one of the 6 payments in the 182 days prior to the Application Raised Date
+    Gross Monthly Income is < £1550.00 in any one of the 6 payments in the 6 months days prior to the Application Raised Date
 
 
 #New Scenario -
@@ -32,7 +32,7 @@ Feature: Failure - Category A Financial Requirement - with no dependents - month
             | Applicant                 | National Insurance Number | JL123456A                     |
             | Category A Monthly Salary | Financial requirement met | false                         |
             | Category A Monthly Salary | Failure reason            | MONTHLY_VALUE_BELOW_THRESHOLD |
-            | Category A Monthly Salary | Assessment start date     | 2014-07-17                    |
+            | Category A Monthly Salary | Assessment start date     | 2014-07-15                    |
             | Category A Monthly Salary | Application Raised date   | 2015-01-15                    |
             | Category A Monthly Salary | Threshold                 | 1550.00                       |
             | Category A Monthly Salary | Employer Name - JL123456A | Flying Pizza Ltd              |
@@ -62,7 +62,7 @@ Feature: Failure - Category A Financial Requirement - with no dependents - month
             | Applicant                 | National Insurance Number | AP123456B                     |
             | Category A Monthly Salary | Financial requirement met | false                         |
             | Category A Monthly Salary | Failure reason            | MONTHLY_VALUE_BELOW_THRESHOLD |
-            | Category A Monthly Salary | Assessment start date     | 2014-09-27                    |
+            | Category A Monthly Salary | Assessment start date     | 2014-09-28                    |
             | Category A Monthly Salary | Application Raised date   | 2015-03-28                    |
             | Category A Monthly Salary | Threshold                 | 1550.00                       |
             | Category A Monthly Salary | Employer Name - AP123456B | Flying Pizza Ltd              |
@@ -90,7 +90,7 @@ Feature: Failure - Category A Financial Requirement - with no dependents - month
             | Applicant                 | National Insurance Number | KS123456C          |
             | Category A Monthly Salary | Financial requirement met | false              |
             | Category A Monthly Salary | Failure reason            | NOT_ENOUGH_RECORDS |
-            | Category A Monthly Salary | Assessment start date     | 2015-01-02         |
+            | Category A Monthly Salary | Assessment start date     | 2015-01-03         |
             | Category A Monthly Salary | Application Raised date   | 2015-07-03         |
             | Category A Monthly Salary | Threshold                 | 1550.00            |
             | Category A Monthly Salary | Employer Name - KS123456C | Flying Pizza Ltd   |
@@ -100,7 +100,7 @@ Feature: Failure - Category A Financial Requirement - with no dependents - month
     (Despite passing the financial threshold he has only worked for his current employer for 2 months)
 
     Pay date 28th of the month
-    He has received 6 Monthly Gross Income payments of £1600.00 in the 182 day period from two employers
+    He has received 6 Monthly Gross Income payments of £1600.00 in the 6 month period from two employers
     He worked for a different employer before his current employer
 
         Given HMRC has the following income records:
@@ -121,7 +121,7 @@ Feature: Failure - Category A Financial Requirement - with no dependents - month
             | Applicant                 | National Insurance Number | GG987654A                            |
             | Category A Monthly Salary | Financial requirement met | false                                |
             | Category A Monthly Salary | Failure reason            | MULTIPLE_EMPLOYERS                   |
-            | Category A Monthly Salary | Assessment start date     | 2015-03-05                           |
+            | Category A Monthly Salary | Assessment start date     | 2015-03-03                           |
             | Category A Monthly Salary | Application Raised date   | 2015-09-03                           |
             | Category A Monthly Salary | Threshold                 | 1550.00                              |
             | Category A Monthly Salary | Employer Name - GG987654A | Curry House Ltd, Office Supplies Ltd |
@@ -130,7 +130,7 @@ Feature: Failure - Category A Financial Requirement - with no dependents - month
     Scenario: David Jones does not meet the Category A employment duration Requirement (Despite passing the financial threshold he has two current active employers)
 
     Pay date is 28th of the month
-    He has received 12 Monthly Gross Income payments of £900.00 and £1200.00 in the 182 day period from two employers
+    He has received 12 Monthly Gross Income payments of £900.00 and £1200.00 in the 6 month period from two employers
 
         Given HMRC has the following income records:
             | Date       | Amount  | Week Number | Month Number | PAYE Reference | Employer        |
@@ -156,7 +156,7 @@ Feature: Failure - Category A Financial Requirement - with no dependents - month
             | Applicant                 | National Insurance Number | AA987654A                     |
             | Category A Monthly Salary | Financial requirement met | false                         |
             | Category A Monthly Salary | Failure reason            | NON_CONSECUTIVE_MONTHS        |
-            | Category A Monthly Salary | Assessment start date     | 2015-03-05                    |
+            | Category A Monthly Salary | Assessment start date     | 2015-03-03                    |
             | Category A Monthly Salary | Application Raised date   | 2015-09-03                    |
             | Category A Monthly Salary | Threshold                 | 1550.00                       |
             | Category A Monthly Salary | Employer Name - AA987654A | Curry House Ltd, Johns Chippy |
@@ -188,7 +188,7 @@ Feature: Failure - Category A Financial Requirement - with no dependents - month
             | Applicant                               | National Insurance Number | JW984624A            |
             | Category A Unsupported Salary Frequency | Financial requirement met | false                |
             | Category A Unsupported Salary Frequency | Failure reason            | PAY_FREQUENCY_CHANGE |
-            | Category A Unsupported Salary Frequency | Assessment start date     | 2015-05-24           |
+            | Category A Unsupported Salary Frequency | Assessment start date     | 2015-05-22           |
             | Category A Unsupported Salary Frequency | Application Raised date   | 2015-11-22           |
             | Category A Unsupported Salary Frequency | Threshold                 | 0                    |
             | Category A Unsupported Salary Frequency | Employer Name - JW984624A | Flying Pizza Ltd     |
@@ -218,7 +218,7 @@ Feature: Failure - Category A Financial Requirement - with no dependents - month
             | Applicant                 | National Insurance Number | JL123456A          |
             | Category A Monthly Salary | Financial requirement met | false              |
             | Category A Monthly Salary | Failure reason            | NOT_ENOUGH_RECORDS |
-            | Category A Monthly Salary | Assessment start date     | 2014-07-17         |
+            | Category A Monthly Salary | Assessment start date     | 2014-07-15         |
             | Category A Monthly Salary | Application Raised date   | 2015-01-15         |
             | Category A Monthly Salary | Threshold                 | 1550.00            |
             | Category A Monthly Salary | Employer Name - JL123456A | Flying Pizza Ltd   |
@@ -243,5 +243,5 @@ Feature: Failure - Category A Financial Requirement - with no dependents - month
             | Applicant                 | National Insurance Number | JL123456A          |
             | Category A Monthly Salary | Financial requirement met | false              |
             | Category A Monthly Salary | Failure reason            | NOT_ENOUGH_RECORDS |
-            | Category A Monthly Salary | Assessment start date     | 2014-07-17         |
+            | Category A Monthly Salary | Assessment start date     | 2014-07-15         |
             | Category A Monthly Salary | Application Raised date   | 2015-01-15         |

--- a/src/test/specs/API-v2/TMFM4_Failure - Category A Financial Requirement (with no dependents - weekly pay).feature
+++ b/src/test/specs/API-v2/TMFM4_Failure - Category A Financial Requirement (with no dependents - weekly pay).feature
@@ -1,10 +1,10 @@
 Feature: Failure - Category A Financial Requirement with no dependents - weekly pay)
 
     Requirement to meet Category A
-    Applicant or Sponsor has received < 26 payments from the same employer over 182 day period prior to the Application Raised Date
+    Applicant or Sponsor has received < 26 payments from the same employer over 6 month period prior to the Application Raised Date
 
     Financial employment income regulation to pass this Feature File
-    Applicant or Sponsor has received 26 weekly Gross Income payments of < £357.69 in the 182 day period prior to the Application Raised Date
+    Applicant or Sponsor has received 26 weekly Gross Income payments of < £357.69 in the 6 month period prior to the Application Raised Date
 
 #New Scenario -
     Scenario: Davina Love does not meet the Category A Financial Requirement (She has earned < the Cat A financial threshold)
@@ -49,7 +49,7 @@ Feature: Failure - Category A Financial Requirement with no dependents - weekly 
             | Applicant                | National Insurance Number | SP123456A                    |
             | Category A Weekly Salary | Financial requirement met | false                        |
             | Category A Weekly Salary | Failure reason            | WEEKLY_VALUE_BELOW_THRESHOLD |
-            | Category A Weekly Salary | Assessment start date     | 2015-05-05                   |
+            | Category A Weekly Salary | Assessment start date     | 2015-05-03                   |
             | Category A Weekly Salary | Application Raised date   | 2015-11-03                   |
             | Category A Weekly Salary | Threshold                 | 357.69                       |
             | Category A Weekly Salary | Employer Name - SP123456A | Flying Pizza Ltd             |
@@ -101,7 +101,7 @@ Feature: Failure - Category A Financial Requirement with no dependents - weekly 
             | Applicant                | National Insurance Number | PY123456B                    |
             | Category A Weekly Salary | Financial requirement met | false                        |
             | Category A Weekly Salary | Failure reason            | WEEKLY_VALUE_BELOW_THRESHOLD |
-            | Category A Weekly Salary | Assessment start date     | 2015-05-05                   |
+            | Category A Weekly Salary | Assessment start date     | 2015-05-03                   |
             | Category A Weekly Salary | Application Raised date   | 2015-11-03                   |
             | Category A Weekly Salary | Threshold                 | 357.69                       |
             | Category A Weekly Salary | Employer Name - PY123456B | Flying Pizza Ltd             |
@@ -151,7 +151,7 @@ Feature: Failure - Category A Financial Requirement with no dependents - weekly 
             | Applicant                | National Insurance Number | RP123456C                          |
             | Category A Weekly Salary | Financial requirement met | false                              |
             | Category A Weekly Salary | Failure reason            | MULTIPLE_EMPLOYERS                 |
-            | Category A Weekly Salary | Assessment start date     | 2015-05-05                         |
+            | Category A Weekly Salary | Assessment start date     | 2015-05-03                         |
             | Category A Weekly Salary | Application Raised date   | 2015-11-03                         |
             | Category A Weekly Salary | Threshold                 | 357.69                             |
             | Category A Weekly Salary | Employer Name - RP123456C | Flying Pizza Ltd, Crazy Pizza  Ltd |
@@ -200,7 +200,7 @@ Feature: Failure - Category A Financial Requirement with no dependents - weekly 
             | Applicant                | National Insurance Number | JJ123456A          |
             | Category A Weekly Salary | Financial requirement met | false              |
             | Category A Weekly Salary | Failure reason            | NOT_ENOUGH_RECORDS |
-            | Category A Weekly Salary | Assessment start date     | 2015-05-05         |
+            | Category A Weekly Salary | Assessment start date     | 2015-05-03         |
             | Category A Weekly Salary | Application Raised date   | 2015-11-03         |
             | Category A Weekly Salary | Threshold                 | 357.69             |
             | Category A Weekly Salary | Employer Name - JJ123456A | Flying Pizza Ltd   |
@@ -208,7 +208,7 @@ Feature: Failure - Category A Financial Requirement with no dependents - weekly 
 
     Scenario: Gary Goldstein does not meet the Category A Employment Requirement (He currently works for two employers)
 
-    He has received 26 Weekly Gross Income payments of £260.60 and £300.00 in the 182 day period from two active employers.  Combined the totals are above the threshold, however this will trigger a failed result.
+    He has received 26 Weekly Gross Income payments of £260.60 and £300.00 in the 6 month period from two active employers.  Combined the totals are above the threshold, however this will trigger a failed result.
 
         Given HMRC has the following income records:
             | Date       | Amount | Week Number | Month Number | PAYE Reference | Employer         |
@@ -274,7 +274,7 @@ Feature: Failure - Category A Financial Requirement with no dependents - weekly 
             | Applicant                | National Insurance Number | GG987654A                         |
             | Category A Weekly Salary | Financial requirement met | false                             |
             | Category A Weekly Salary | Failure reason            | WEEKLY_VALUE_BELOW_THRESHOLD      |
-            | Category A Weekly Salary | Assessment start date     | 2015-03-05                        |
+            | Category A Weekly Salary | Assessment start date     | 2015-03-03                        |
             | Category A Weekly Salary | Application Raised date   | 2015-09-03                        |
             | Category A Weekly Salary | Threshold                 | 357.69                            |
             | Category A Weekly Salary | Employer Name - GG987654A | Curry House Ltd, Flying Pizza Ltd |
@@ -327,7 +327,7 @@ Feature: Failure - Category A Financial Requirement with no dependents - weekly 
             | Applicant                | National Insurance Number | PJ123456A                         |
             | Category A Weekly Salary | Financial requirement met | false                             |
             | Category A Weekly Salary | Failure reason            | WEEKLY_VALUE_BELOW_THRESHOLD      |
-            | Category A Weekly Salary | Assessment start date     | 2015-05-05                        |
+            | Category A Weekly Salary | Assessment start date     | 2015-05-03                        |
             | Category A Weekly Salary | Application Raised date   | 2015-11-03                        |
             | Category A Weekly Salary | Threshold                 | 357.69                            |
             | Category A Weekly Salary | Employer Name - PJ123456A | Flying Pizza Ltd, Mambo Pizza Ltd |
@@ -372,7 +372,7 @@ Feature: Failure - Category A Financial Requirement with no dependents - weekly 
             | Applicant                | National Insurance Number | PP123456A          |
             | Category A Weekly Salary | Financial requirement met | false              |
             | Category A Weekly Salary | Failure reason            | NOT_ENOUGH_RECORDS |
-            | Category A Weekly Salary | Assessment start date     | 2015-05-05         |
+            | Category A Weekly Salary | Assessment start date     | 2015-05-03         |
             | Category A Weekly Salary | Application Raised date   | 2015-11-03         |
             | Category A Weekly Salary | Threshold                 | 357.69             |
             | Category A Weekly Salary | Employer Name - PP123456A | Flying Pizza Ltd   |
@@ -415,7 +415,7 @@ Feature: Failure - Category A Financial Requirement with no dependents - weekly 
             | Applicant                               | National Insurance Number | PP123456A            |
             | Category A Unsupported Salary Frequency | Financial requirement met | false                |
             | Category A Unsupported Salary Frequency | Failure reason            | PAY_FREQUENCY_CHANGE |
-            | Category A Unsupported Salary Frequency | Assessment start date     | 2014-11-11           |
+            | Category A Unsupported Salary Frequency | Assessment start date     | 2014-11-12           |
             | Category A Unsupported Salary Frequency | Application Raised date   | 2015-05-12           |
             | Category A Unsupported Salary Frequency | Threshold                 | 0                    |
             | Category A Unsupported Salary Frequency | Employer Name - PP123456A | Flying Pizza Ltd     |

--- a/src/test/specs/API-v2/TMFM5_Pass - Category A Financial Requirement (with dependents - monthly).feature
+++ b/src/test/specs/API-v2/TMFM5_Pass - Category A Financial Requirement (with dependents - monthly).feature
@@ -1,15 +1,15 @@
 Feature: Pass - Category A Financial Requirement - with dependants - monthly
 
     Requirement to meet Category A
-    Applicant or Sponsor has received 6 consecutive monthly payments from the same employer over the 182 day period prior to the Application Raised Date
+    Applicant or Sponsor has received 6 consecutive monthly payments from the same employer over the 6 month period prior to the Application Raised Date
 
     Financial income regulation to pass this Feature File
-    Income required amount no dependant child = £18600 (They have earned 6 monthly payments => £1550 Monthly Gross Income in the 182 days prior to the Application Raised Date)
+    Income required amount no dependant child = £18600 (They have earned 6 monthly payments => £1550 Monthly Gross Income in the 6 months prior to the Application Raised Date)
     Additional funds for 1 dependant child = £3800 on top of employment threshold
     Additional funds for EVERY subsequent dependant child = £2400 on top of employment threshold per child
 
     Financial income calculation to pass this Feature File
-    Income required amount + 1 dependant amount + (Additional dependant amount * number of dependants)/12 = Equal to or greater than the threshold Monthly Gross Income in the 182 days prior to the Application Raised Date
+    Income required amount + 1 dependant amount + (Additional dependant amount * number of dependants)/12 = Equal to or greater than the threshold Monthly Gross Income in the 6 months prior to the Application Raised Date
 
     1 Dependant child - £18600+£3800/12 = £1866.67
     2 Dependant children - £18600+£3800+£2400/12 = £2066.67
@@ -44,7 +44,7 @@ Feature: Pass - Category A Financial Requirement - with dependants - monthly
             | HTTP Response             | HTTP Status               | 200              |
             | Applicant                 | National Insurance Number | TL123456A        |
             | Category A Monthly Salary | Financial requirement met | true             |
-            | Category A Monthly Salary | Assessment start date     | 2014-07-25       |
+            | Category A Monthly Salary | Assessment start date     | 2014-07-23       |
             | Category A Monthly Salary | Application Raised date   | 2015-01-23       |
             | Category A Monthly Salary | Threshold                 | 1866.67          |
             | Category A Monthly Salary | Employer Name - TL123456A | Flying Pizza Ltd |
@@ -75,7 +75,7 @@ Feature: Pass - Category A Financial Requirement - with dependants - monthly
             | HTTP Response             | HTTP Status               | 200              |
             | Applicant                 | National Insurance Number | SJ123456C        |
             | Category A Monthly Salary | Financial requirement met | true             |
-            | Category A Monthly Salary | Assessment start date     | 2015-06-09       |
+            | Category A Monthly Salary | Assessment start date     | 2015-06-08       |
             | Category A Monthly Salary | Application Raised date   | 2015-12-08       |
             | Category A Monthly Salary | Threshold                 | 2266.67          |
             | Category A Monthly Salary | Employer Name - SJ123456C | Flying Pizza Ltd |
@@ -105,7 +105,7 @@ Feature: Pass - Category A Financial Requirement - with dependants - monthly
             | HTTP Response             | HTTP Status               | 200              |
             | Applicant                 | National Insurance Number | WA987654B        |
             | Category A Monthly Salary | Financial requirement met | true             |
-            | Category A Monthly Salary | Assessment start date     | 2014-08-30       |
+            | Category A Monthly Salary | Assessment start date     | 2014-08-28       |
             | Category A Monthly Salary | Application Raised date   | 2015-02-28       |
             | Category A Monthly Salary | Threshold                 | 2666.67          |
             | Category A Monthly Salary | Employer Name - WA987654B | Flying Pizza Ltd |

--- a/src/test/specs/API-v2/TMFM6_Pass - Category A Financial Requirement (with dependents - weekly pay).feature
+++ b/src/test/specs/API-v2/TMFM6_Pass - Category A Financial Requirement (with dependents - weekly pay).feature
@@ -1,7 +1,7 @@
 Feature: Pass - Category A Financial Requirement  - with Dependants - weekly pay
 
     Requirement to meet Category A
-    Applicant or Sponsor has received 26 payments from the same employer over 182 day period prior to the Application Raised Date
+    Applicant or Sponsor has received 26 payments from the same employer over 6 month period prior to the Application Raised Date
 
     Financial income regulation to pass this Feature File
     Income required amount no dependant child = £18600 (£1550 per month or above for EACH of the previous 6 months from the Application Raised Date)
@@ -9,7 +9,7 @@ Feature: Pass - Category A Financial Requirement  - with Dependants - weekly pay
     Additional funds for EVERY subsequent dependant child = £2400 on top of employment threshold per child
 
     Financial income calculation to pass this Feature File
-    Income required amount + 1 dependant amount + (Additional dependant amount * number of dependants)/52 weeks in the year = 26 Weekly Gross Income payments => threshold in the 182 day period prior to the Application Raised Date
+    Income required amount + 1 dependant amount + (Additional dependant amount * number of dependants)/52 weeks in the year = 26 Weekly Gross Income payments => threshold in the 6 month period prior to the Application Raised Date
 
     1 Dependant child - £18600+£3800/52 = £430.77
     2 Dependant children - £18600+£3800+£2400/12 = £476.92
@@ -62,7 +62,7 @@ Feature: Pass - Category A Financial Requirement  - with Dependants - weekly pay
             | HTTP Response            | HTTP Status               | 200              |
             | Applicant                | National Insurance Number | TS123456A        |
             | Category A Weekly Salary | Financial requirement met | true             |
-            | Category A Weekly Salary | Assessment start date     | 2015-08-25       |
+            | Category A Weekly Salary | Assessment start date     | 2015-08-23       |
             | Category A Weekly Salary | Application Raised date   | 2016-02-23       |
             | Category A Weekly Salary | Threshold                 | 430.77           |
             | Category A Weekly Salary | Employer Name - TS123456A | Flying Pizza Ltd |
@@ -111,7 +111,7 @@ Feature: Pass - Category A Financial Requirement  - with Dependants - weekly pay
             | HTTP Response            | HTTP Status               | 200              |
             | Applicant                | National Insurance Number | JT123456C        |
             | Category A Weekly Salary | Financial requirement met | true             |
-            | Category A Weekly Salary | Assessment start date     | 2015-06-05       |
+            | Category A Weekly Salary | Assessment start date     | 2015-06-04       |
             | Category A Weekly Salary | Application Raised date   | 2015-12-04       |
             | Category A Weekly Salary | Threshold                 | 523.08           |
             | Category A Weekly Salary | Employer Name - JT123456C | Flying Pizza Ltd |
@@ -160,7 +160,7 @@ Feature: Pass - Category A Financial Requirement  - with Dependants - weekly pay
             | HTTP Response            | HTTP Status               | 200              |
             | Applicant                | National Insurance Number | PS987654B        |
             | Category A Weekly Salary | Financial requirement met | true             |
-            | Category A Weekly Salary | Assessment start date     | 2015-01-21       |
+            | Category A Weekly Salary | Assessment start date     | 2015-01-22       |
             | Category A Weekly Salary | Application Raised date   | 2015-07-22       |
             | Category A Weekly Salary | Threshold                 | 615.38           |
             | Category A Weekly Salary | Employer Name - PS987654B | Flying Pizza Ltd |

--- a/src/test/specs/API-v2/TMFM7_Pass - Category A Financial Requirement (with no dependents - weekly pay).feature
+++ b/src/test/specs/API-v2/TMFM7_Pass - Category A Financial Requirement (with no dependents - weekly pay).feature
@@ -1,10 +1,10 @@
 Feature: Pass - Category A Financial Requirement - with no dependents - weekly pay
 
     Requirement to meet Category A
-    Applicant or Sponsor has received 26 payments from the same employer over 182 day period prior to the Application Raised Date
+    Applicant or Sponsor has received 26 payments from the same employer over 6 month period prior to the Application Raised Date
 
     Financial employment income regulation to pass this Feature File
-    Applicant or Sponsor has received 26 weekly Gross Income payments of => £357.69 in the 182 day period prior to the Application Raised Date
+    Applicant or Sponsor has received 26 weekly Gross Income payments of => £357.69 in the 6 month period prior to the Application Raised Date
 
 #New Scenario -
     Scenario: Molly Henry meets the Category A Financial Requirement
@@ -48,7 +48,7 @@ Feature: Pass - Category A Financial Requirement - with no dependents - weekly p
             | HTTP Response            | HTTP Status               | 200              |
             | Applicant                | National Insurance Number | MH123456A        |
             | Category A Weekly Salary | Financial requirement met | true             |
-            | Category A Weekly Salary | Assessment start date     | 2015-05-31       |
+            | Category A Weekly Salary | Assessment start date     | 2015-05-29       |
             | Category A Weekly Salary | Application Raised date   | 2015-11-29       |
             | Category A Weekly Salary | Threshold                 | 357.69           |
             | Category A Weekly Salary | Employer Name - MH123456A | Flying Pizza Ltd |

--- a/src/test/specs/API-v2/TMFM8_Pass - Category A Financial Requirement (with no dependents - monthly pay).feature
+++ b/src/test/specs/API-v2/TMFM8_Pass - Category A Financial Requirement (with no dependents - monthly pay).feature
@@ -1,10 +1,10 @@
 Feature: Pass - Category A Financial Requirement - with no dependents - monthly pay
 
     Requirement to meet Category A
-    Applicant or Sponsor has received 6 consecutive monthly payments from the same employer over the 182 day period prior to the Application Raised Date
+    Applicant or Sponsor has received 6 consecutive monthly payments from the same employer over the 6 month period prior to the Application Raised Date
 
     Financial employment income regulation to pass this Feature File
-    Applicant or Sponsor has earned 6 monthly payments => £1550 Monthly Gross Income in the 182 days prior to the Application Raised Date
+    Applicant or Sponsor has earned 6 monthly payments => £1550 Monthly Gross Income in the 6 months prior to the Application Raised Date
 
 #New Scenario -
     Scenario: Jon meets the Category A Financial Requirement (1)
@@ -30,7 +30,7 @@ Feature: Pass - Category A Financial Requirement - with no dependents - monthly 
             | Applicant                 | National Insurance Number | AA345678A        |
             | HTTP Response             | HTTP Status               | 200              |
             | Category A Monthly Salary | Financial requirement met | true             |
-            | Category A Monthly Salary | Assessment start date     | 2014-07-25       |
+            | Category A Monthly Salary | Assessment start date     | 2014-07-23       |
             | Category A Monthly Salary | Application Raised date   | 2015-01-23       |
             | Category A Monthly Salary | Threshold                 | 1550.00          |
             | Category A Monthly Salary | Employer Name - AA345678A | Flying Pizza Ltd |
@@ -59,7 +59,7 @@ Feature: Pass - Category A Financial Requirement - with no dependents - monthly 
             | HTTP Response             | HTTP Status               | 200              |
             | Applicant                 | National Insurance Number | AA123456B        |
             | Category A Monthly Salary | Financial requirement met | true             |
-            | Category A Monthly Salary | Assessment start date     | 2014-07-12       |
+            | Category A Monthly Salary | Assessment start date     | 2014-07-10       |
             | Category A Monthly Salary | Application Raised date   | 2015-01-10       |
             | Category A Monthly Salary | Threshold                 | 1550.00          |
             | Category A Monthly Salary | Employer Name - AA123456B | Flying Pizza Ltd |
@@ -89,7 +89,7 @@ Feature: Pass - Category A Financial Requirement - with no dependents - monthly 
             | HTTP Response             | HTTP Status               | 200              |
             | Applicant                 | National Insurance Number | BB123456B        |
             | Category A Monthly Salary | Financial requirement met | true             |
-            | Category A Monthly Salary | Assessment start date     | 2014-07-25       |
+            | Category A Monthly Salary | Assessment start date     | 2014-07-23       |
             | Category A Monthly Salary | Application Raised date   | 2015-01-23       |
             | Category A Monthly Salary | Threshold                 | 1550.00          |
             | Category A Monthly Salary | Employer Name - BB123456B | Flying Pizza Ltd |
@@ -119,7 +119,7 @@ Feature: Pass - Category A Financial Requirement - with no dependents - monthly 
             | HTTP Response             | HTTP Status               | 200              |
             | Applicant                 | National Insurance Number | CC123456C        |
             | Category A Monthly Salary | Financial requirement met | true             |
-            | Category A Monthly Salary | Assessment start date     | 2014-07-25       |
+            | Category A Monthly Salary | Assessment start date     | 2014-07-23       |
             | Category A Monthly Salary | Application Raised date   | 2015-01-23       |
             | Category A Monthly Salary | Threshold                 | 1550.00          |
             | Category A Monthly Salary | Employer Name - CC123456C | Flying Pizza Ltd |
@@ -149,7 +149,7 @@ Feature: Pass - Category A Financial Requirement - with no dependents - monthly 
             | HTTP Response             | HTTP Status               | 200              |
             | Applicant                 | National Insurance Number | CC123456B        |
             | Category A Monthly Salary | Financial requirement met | true             |
-            | Category A Monthly Salary | Assessment start date     | 2014-07-11       |
+            | Category A Monthly Salary | Assessment start date     | 2014-07-09       |
             | Category A Monthly Salary | Application Raised date   | 2015-01-09       |
             | Category A Monthly Salary | Threshold                 | 1550.00          |
             | Category A Monthly Salary | Employer Name - CC123456B | Flying Pizza Ltd |
@@ -180,7 +180,7 @@ Feature: Pass - Category A Financial Requirement - with no dependents - monthly 
             | HTTP Response             | HTTP Status               | 200              |
             | Applicant                 | National Insurance Number | AA123456A        |
             | Category A Monthly Salary | Financial requirement met | true             |
-            | Category A Monthly Salary | Assessment start date     | 2014-07-25       |
+            | Category A Monthly Salary | Assessment start date     | 2014-07-23       |
             | Category A Monthly Salary | Application Raised date   | 2015-01-23       |
             | Category A Monthly Salary | Threshold                 | 1550.00          |
             | Category A Monthly Salary | Employer Name - AA123456A | Flying Pizza Ltd |
@@ -211,7 +211,7 @@ Feature: Pass - Category A Financial Requirement - with no dependents - monthly 
             | HTTP Response             | HTTP Status               | 200              |
             | Applicant                 | National Insurance Number | AA123456B        |
             | Category A Monthly Salary | Financial requirement met | true             |
-            | Category A Monthly Salary | Assessment start date     | 2014-07-12       |
+            | Category A Monthly Salary | Assessment start date     | 2014-07-10       |
             | Category A Monthly Salary | Application Raised date   | 2015-01-10       |
             | Category A Monthly Salary | Threshold                 | 1550.00          |
             | Category A Monthly Salary | Employer Name - AA123456B | Flying Pizza Ltd |


### PR DESCRIPTION
Made it so that all Cat A Validators use 6 calendar months ago as the assessment start date rather than 182 days ago.

The old implementation meant that some unit tests started failing when it became September (182 days before 14th September is 16th March whereas 182 days before 14th August is 13th February - in the tests affected all payments are on the 14th of each month so the 14th March payment is wrongly discounted when the test is run in September). These tests have been reinstated and I have manually checked that they shouldn't start failing when the months change.

The fix is to calculate the assessment start date as 6 months prior to the start date (using LocalDate.minusMonths()) rather than 182 days before. I have put this in a static method in CatASalariedValidator which all the different Cat A Validators call in order to reduce duplication of code.

While working in these classes I made a few small improvements pointed out by IntelliJ:

- The lists of checkedIndividuals in all cases are 1 element so used Collections.singletonList over Arrays.asList.

- CatASalariedMonthlyValidator and CatASalariedWeeklyValidator have private methods called financialCheckForMonthlySalaried and financialCheckForWeeklySalaried respectively. These have int arguments called numOfMonths/numOfWeeks which are only ever called with one value each. I have removed the parameters and inlined the values for simplicity.

I have altered all the affected BDD tests so that the assessment start date is 6 months before the aplplicationRaisedDate.
