### PR TITLE
EE 3838 tidy cat a non salaried bdd

### DIFF
--- a/src/test/specs/API-v3-wip/01 - Category A PASS - Solo & Combined (Non-Salaried).feature
+++ b/src/test/specs/API-v3-wip/01 - Category A PASS - Solo & Combined (Non-Salaried).feature
@@ -15,239 +15,232 @@ Feature: Category A Financial Requirement - Solo & Combined Applications for Non
 
 
         Given HMRC has the following income records:
-            | Date       | Amount  | PAYE Reference | Employer         |
-            | 2018-04-27 | 1000.00 | FP/Ref1        | Flying Pizza Ltd |
-            | 2018-03-29 | 2000.00 | FP/Ref1        | Flying Pizza Ltd |
-            | 2018-02-28 | 2000.00 | FP/Ref1        | Flying Pizza Ltd |
-            | 2018-01-31 | 2000.00 | FP/Ref1        | Flying Pizza Ltd |
-            | 2017-12-29 | 1300.00 | FP/Ref1        | Flying Pizza Ltd |
-            | 2017-11-30 | 1000.00 | FP/Ref1        | Flying Pizza Ltd |
+            | Date       | Amount  | Week Number | Month Number | PAYE Reference | Employer         |
+            | 2018-04-27 | 1000.00 |             | 01           | FP/Ref1        | Flying Pizza Ltd |
+            | 2018-03-29 | 2000.00 |             | 12           | FP/Ref1        | Flying Pizza Ltd |
+            | 2018-02-28 | 2000.00 |             | 11           | FP/Ref1        | Flying Pizza Ltd |
+            | 2018-01-31 | 2000.00 |             | 10           | FP/Ref1        | Flying Pizza Ltd |
+            | 2017-12-29 | 1300.00 |             | 09           | FP/Ref1        | Flying Pizza Ltd |
+            | 2017-11-30 | 1000.00 |             | 08           | FP/Ref1        | Flying Pizza Ltd |
 
-        When the Income Proving v2 TM Family API is invoked with the following:
-            | NINO                    | AA345678A  |
+        When the Income Proving v3 TM Family API is invoked with the following:
+            | NINO - Applicant        | AA345678A  |
             | Application Raised Date | 2018-04-30 |
 
         Then The Income Proving TM Family API provides the following result:
-            | HTTP Status               | 200              |
-            | Category                  | A                |
-            | Financial requirement met | true             |
-            | Application Raised date   | 2018-04-30       |
-            | National Insurance Number | AA345678A        |
-            | Threshold                 | 18600            |
-            | Employer Name             | Flying Pizza Ltd |
+            | HTTP Response           | HTTP Status               | 200              |
+            | Applicant               | National Insurance Number | AA345678A        |
+            | Category A Non Salaried | Category                  | A                |
+            | Category A Non Salaried | Financial requirement met | true             |
+            | Category A Non Salaried | Application Raised date   | 2018-04-30       |
+            | Category A Non Salaried | National Insurance Number | AA345678A        |
+            | Category A Non Salaried | Threshold                 | 18600            |
+            | Category A Non Salaried | Employer Name             | Flying Pizza Ltd |
 
 ############
 
     Scenario: 02 David has no dependents. His income history shows payments in 7 months prior that meet the threshold. Assessment range 2018-04-30 to 2017-10-30
 
         Given HMRC has the following income records:
-            | Date       | Amount  | PAYE Reference | Employer         |
-            | 2018-04-30 | 2000.00 | FP/Ref1        | Flying Pizza Ltd |
-            | 2018-03-29 | 2000.00 | FP/Ref1        | Flying Pizza Ltd |
-            | 2018-02-28 | 2000.00 | FP/Ref1        | Flying Pizza Ltd |
-            | 2017-01-31 | 1300.00 | FP/Ref1        | Flying Pizza Ltd |
-            | 2017-12-29 | 1000.00 | FP/Ref1        | Flying Pizza Ltd |
-            | 2017-11-30 |  500.00 | FP/Ref1        | Flying Pizza Ltd |
-            | 2017-10-30 |  500.00 | FP/Ref1        | Flying Pizza Ltd |
+            | Date       | Amount  | Week Number | Month Number | PAYE Reference | Employer         |
+            | 2018-04-30 | 2000.00 |             | 01           | FP/Ref1        | Flying Pizza Ltd |
+            | 2018-03-29 | 2000.00 |             | 12           | FP/Ref1        | Flying Pizza Ltd |
+            | 2018-02-28 | 2000.00 |             | 11           | FP/Ref1        | Flying Pizza Ltd |
+            | 2017-01-31 | 1300.00 |             | 10           | FP/Ref1        | Flying Pizza Ltd |
+            | 2017-12-29 | 1000.00 |             | 09           | FP/Ref1        | Flying Pizza Ltd |
+            | 2017-11-30 | 500.00  |             | 08           | FP/Ref1        | Flying Pizza Ltd |
+            | 2017-10-30 | 500.00  |             | 07           | FP/Ref1        | Flying Pizza Ltd |
 
-        When the Income Proving v2 TM Family API is invoked with the following:
-            | NINO                    | FD345678A  |
+        When the Income Proving v3 TM Family API is invoked with the following:
+            | NINO - Applicant        | GE345678A  |
             | Application Raised Date | 2018-04-30 |
 
         Then The Income Proving TM Family API provides the following result:
-            | HTTP Status               | 200              |
-            | Category                  | A                |
-            | Financial requirement met | true             |
-            | Application Raised date   | 2018-04-30       |
-            | National Insurance Number | FD345678A        |
-            | Threshold                 | 18600            |
-            | Employer Name             | Flying Pizza Ltd |
+            | HTTP Response           | HTTP Status               | 200              |
+            | Category A Non Salaried | Financial requirement met | true             |
+            | Category A Non Salaried | Application Raised date   | 2018-04-30       |
+            | Category A Non Salaried | National Insurance Number | GE345678A        |
+            | Category A Non Salaried | Threshold                 | 18600            |
+            | Category A Non Salaried | Employer Name             | Flying Pizza Ltd |
 
 ############
 
     Scenario: 03 Pauline has no dependents. Her income history shows payments in 6 months that meet the threshold, but ignoring payments from a second employer.  Assessment range 2018-04-30 to 2017-10-30
 
         Given HMRC has the following income records:
-            | Date       | Amount  | PAYE Reference | Employer         |
-            | 2018-04-30 |  500.00 | FP/Ref1        | Flying Pizza Ltd |
-            | 2018-03-29 | 2000.00 | FP/Ref1        | Flying Pizza Ltd |
-            | 2018-02-28 | 2000.00 | FP/Ref1        | Flying Pizza Ltd |
-            | 2018-01-31 | 2000.00 | FP/Ref1        | Flying Pizza Ltd |
-            | 2017-12-29 | 1000.00 | FP/Ref2        | Flowers 4U Ltd   |
-            | 2017-11-30 | 2300.00 | FP/Ref1        | Flying Pizza Ltd |
-            | 2017-10-30 |  500.00 | FP/Ref1        | Flying Pizza Ltd |
+            | Date       | Amount  | Week Number | Month Number | PAYE Reference | Employer         |
+            | 2018-04-30 | 500.00  |             | 01           | FP/Ref1        | Flying Pizza Ltd |
+            | 2018-03-29 | 2000.00 |             | 12           | FP/Ref1        | Flying Pizza Ltd |
+            | 2018-02-28 | 2000.00 |             | 11           | FP/Ref1        | Flying Pizza Ltd |
+            | 2018-01-31 | 2000.00 |             | 10           | FP/Ref1        | Flying Pizza Ltd |
+            | 2017-12-29 | 1000.00 |             | 09           | FP/Ref2        | Flowers 4U Ltd   |
+            | 2017-11-30 | 2300.00 |             | 08           | FP/Ref1        | Flying Pizza Ltd |
+            | 2017-10-30 | 500.00  |             | 07           | FP/Ref1        | Flying Pizza Ltd |
 
-        When the Income Proving v2 TM Family API is invoked with the following:
-            | NINO                    | VB345678A  |
+        When the Income Proving v3 TM Family API is invoked with the following:
+            | NINO - Applicant        | EB345678A  |
             | Application Raised Date | 2018-04-30 |
 
         Then The Income Proving TM Family API provides the following result:
-            | HTTP Status               | 200                              |
-            | Category                  | A                                |
-            | Financial requirement met | true                             |
-            | Application Raised date   | 2018-04-30                       |
-            | National Insurance Number | VB345678A                        |
-            | Threshold                 | 18600                            |
-            | Employer Name             | Flying Pizza Ltd, Flowers 4U Ltd |
+            | HTTP Response           | HTTP Status               | 200                              |
+            | Category A Non Salaried | Financial requirement met | true                             |
+            | Category A Non Salaried | Application Raised date   | 2018-04-30                       |
+            | Category A Non Salaried | National Insurance Number | EB345678A                        |
+            | Category A Non Salaried | Threshold                 | 18600                            |
+            | Category A Non Salaried | Employer Name             | Flying Pizza Ltd, Flowers 4U Ltd |
 
 ############
 
     Scenario: 04 Sarah has no dependants. Her income history shows a payment that meets the threshold at the very beginning of the 6 month range. All other months are blank. Assessment range 2017-12-30 to 2017-07-01.
 
         Given HMRC has the following income records:
-            | Date       | Amount  | PAYE Reference | Employer         |
-            | 2017-12-30 | 9300.00 | FP/Ref1        | Flying Pizza Ltd |
+            | Date       | Amount  | Week Number | Month Number | PAYE Reference | Employer         |
+            | 2017-12-30 | 9300.00 |             | 01           | FP/Ref1        | Flying Pizza Ltd |
 
 
-        When the Income Proving v2 TM Family API is invoked with the following:
-            | NINO                    | JH573849A  |
+        When the Income Proving v3 TM Family API is invoked with the following:
+            | NINO - Applicant        | JH573849A  |
             | Application Raised Date | 2017-12-30 |
 
         Then The Income Proving TM Family API provides the following result:
-            | HTTP Status               | 200              |
-            | Category                  | A                |
-            | Financial requirement met | true             |
-            | Application Raised date   | 2017-12-30       |
-            | National Insurance Number | JH573849A        |
-            | Threshold                 | 18600            |
-            | Employer Name             | Flying Pizza Ltd |
+            | HTTP Response           | HTTP Status               | 200              |
+            | Category A Non Salaried | Financial requirement met | true             |
+            | Category A Non Salaried | Application Raised date   | 2017-12-30       |
+            | Category A Non Salaried | National Insurance Number | JH573849A        |
+            | Category A Non Salaried | Threshold                 | 18600            |
+            | Category A Non Salaried | Employer Name             | Flying Pizza Ltd |
 
 ############
 
     Scenario: 05 Sally has no dependants. Her income history shows a payment that meets the threshold at the very end of the 6 month range. All other months are blank. Assessment range 2017-12-30 to 2017-07-01.
 
         Given HMRC has the following income records:
-            | Date       | Amount  | PAYE Reference | Employer         |
-            | 2017-07-01 | 9300.00 | FP/Ref1        | Flying Pizza Ltd |
+            | Date       | Amount  | Week Number | Month Number | PAYE Reference | Employer         |
+            | 2017-07-01 | 9300.00 |             | 01           | FP/Ref1        | Flying Pizza Ltd |
 
 
-        When the Income Proving v2 TM Family API is invoked with the following:
-            | NINO                    | KL927581A  |
+        When the Income Proving v3 TM Family API is invoked with the following:
+            | NINO - Applicant        | KL927581A  |
             | Application Raised Date | 2017-12-30 |
 
         Then The Income Proving TM Family API provides the following result:
-            | HTTP Status               | 200              |
-            | Category                  | A                |
-            | Financial requirement met | true             |
-            | Application Raised date   | 2017-12-30       |
-            | National Insurance Number | KL927581A        |
-            | Threshold                 | 18600            |
-            | Employer Name             | Flying Pizza Ltd |
+            | HTTP Response           | HTTP Status               | 200              |
+            | Category A Non Salaried | Financial requirement met | true             |
+            | Category A Non Salaried | Application Raised date   | 2017-12-30       |
+            | Category A Non Salaried | National Insurance Number | KL927581A        |
+            | Category A Non Salaried | Threshold                 | 18600            |
+            | Category A Non Salaried | Employer Name             | Flying Pizza Ltd |
 
 ############
 
     Scenario: 06 Phillip has no dependents. His income history shows 6 months with payments. One month has weekly payments and another month has fortnightly and a monthly payment. Average meets the threshold. Assessment range 2017-09-30 to 2017-04-01.
 
         Given HMRC has the following income records:
-            | Date       | Amount  | PAYE Reference | Employer         |
-            | 2017-09-29 | 2000.00 | FP/Ref1        | Flying Pizza Ltd |
-            | 2017-08-25 | 2000.00 | FP/Ref1        | Flying Pizza Ltd |
-            | 2017-07-28 | 2000.00 | FP/Ref1        | Flying Pizza Ltd |
-            | 2017-06-30 |  325.00 | FP/Ref2        | Flying Pizza Ltd |
-            | 2017-06-23 |  325.00 | FP/Ref2        | Flying Pizza Ltd |
-            | 2017-06-16 |  325.00 | FP/Ref2        | Flying Pizza Ltd |
-            | 2017-06-09 |  325.00 | FP/Ref2        | Flying Pizza Ltd |
-            | 2017-05-26 | 1000.00 | FP/Ref1        | Flying Pizza Ltd |
-            | 2017-04-28 |  500.00 | FP/Ref1        | Flying Pizza Ltd |
-            | 2017-04-07 |  500.00 | FP/Ref2        | Flying Pizza Ltd |
+            | Date       | Amount  | Week Number | Month Number | PAYE Reference | Employer         |
+            | 2017-09-29 | 2000.00 |             | 01           | FP/Ref1        | Flying Pizza Ltd |
+            | 2017-08-25 | 2000.00 |             | 12           | FP/Ref1        | Flying Pizza Ltd |
+            | 2017-07-28 | 2000.00 |             | 11           | FP/Ref1        | Flying Pizza Ltd |
+            | 2017-06-30 | 325.00  |             | 10           | FP/Ref2        | Flying Pizza Ltd |
+            | 2017-06-23 | 325.00  |             | 09           | FP/Ref2        | Flying Pizza Ltd |
+            | 2017-06-16 | 325.00  |             | 08           | FP/Ref2        | Flying Pizza Ltd |
+            | 2017-06-09 | 325.00  |             | 07           | FP/Ref2        | Flying Pizza Ltd |
+            | 2017-05-26 | 1000.00 |             | 06           | FP/Ref1        | Flying Pizza Ltd |
+            | 2017-04-28 | 500.00  |             | 05           | FP/Ref1        | Flying Pizza Ltd |
+            | 2017-04-07 | 500.00  | 03          |              | FP/Ref2        | Flying Pizza Ltd |
 
-        When the Income Proving v2 TM Family API is invoked with the following:
-            | NINO                    | AB889357A  |
+        When the Income Proving v3 TM Family API is invoked with the following:
+            | NINO - Applicant        | AB889357A  |
             | Application Raised Date | 2017-09-30 |
 
         Then The Income Proving TM Family API provides the following result:
-            | HTTP Status               | 200              |
-            | Category                  | A                |
-            | Financial requirement met | true             |
-            | Application Raised date   | 2017-09-30       |
-            | National Insurance Number | AAB889357A        |
-            | Threshold                 | 18600            |
-            | Employer Name             | Flying Pizza Ltd |
+            | HTTP Response           | HTTP Status               | 200              |
+            | Category A Non Salaried | Financial requirement met | true             |
+            | Category A Non Salaried | Application Raised date   | 2017-09-30       |
+            | Category A Non Salaried | National Insurance Number | AAB889357A       |
+            | Category A Non Salaried | Threshold                 | 18600            |
+            | Category A Non Salaried | Employer Name             | Flying Pizza Ltd |
 
 ############
 
     Scenario: 07 Siobhan has one dependent. Her income history shows a payment in 6 months with a mixture of payments and gaps that meet the threshold (Nov & Sept are blank). Assessment range 2018-01-31 to 2017-08-02.
 
         Given HMRC has the following income records:
-            | Date       | Amount  | PAYE Reference | Employer         |
-            | 2018-01-26 | 5000.00 | FP/Ref1        | Flying Pizza Ltd |
-            | 2017-12-22 | 5000.00 | FP/Ref1        | Flying Pizza Ltd |
-            | 2017-10-27 | 1000.00 | FP/Ref1        | Flying Pizza Ltd |
-            | 2017-08-31 |  200.00 | FP/Ref1        | Flying Pizza Ltd |
+            | Date       | Amount  | Week Number | Month Number | PAYE Reference | Employer         |
+            | 2018-01-26 | 5000.00 |             | 10           | FP/Ref1        | Flying Pizza Ltd |
+            | 2017-12-22 | 5000.00 |             | 09           | FP/Ref1        | Flying Pizza Ltd |
+            | 2017-10-27 | 1000.00 |             | 07           | FP/Ref1        | Flying Pizza Ltd |
+            | 2017-08-31 | 200.00  |             | 05           | FP/Ref1        | Flying Pizza Ltd |
 
-        When the Income Proving v2 TM Family API is invoked with the following:
-            | NINO                    | LA345628A  |
+        When the Income Proving v3 TM Family API is invoked with the following:
+            | NINO - Applicant        | LA345628A  |
             | Application Raised Date | 2018-01-31 |
 
         Then The Income Proving TM Family API provides the following result:
-            | HTTP Status               | 200              |
-            | Category                  | A                |
-            | Financial requirement met | true             |
-            | Application Raised date   | 2018-01-31       |
-            | National Insurance Number | LA345628A        |
-            | Threshold                 | £22400           |
-            | Employer Name             | Flying Pizza Ltd |
+            | HTTP Response           | HTTP Status               | 200              |
+            | Category A Non Salaried | Financial requirement met | true             |
+            | Category A Non Salaried | Application Raised date   | 2018-01-31       |
+            | Category A Non Salaried | National Insurance Number | LA345628A        |
+            | Category A Non Salaried | Threshold                 | £22400           |
+            | Category A Non Salaried | Employer Name             | Flying Pizza Ltd |
 
 ############
 
     Scenario: 08 Derek has two dependents. His income history shows a payment in 6 months with a mixture of payments and gaps that meet the threshold (Nov, Oct & Sept are blank). Assessment range 2017-01-31 to 2017-08-02.
 
         Given HMRC has the following income records:
-            | Date       | Amount  | PAYE Reference | Employer         |
-            | 2018-01-26 | 5000.00 | FP/Ref1        | Flying Pizza Ltd |
-            | 2017-12-22 | 1800.00 | FP/Ref1        | Flying Pizza Ltd |
-            | 2017-12-08 |  600.00 | FP/Ref2        | Flying Pizza Ltd |
-            | 2017-08-31 | 5000.00 | FP/Ref1        | Flying Pizza Ltd |
+            | Date       | Amount  | Week Number | Month Number | PAYE Reference | Employer         |
+            | 2018-01-26 | 5000.00 |             | 10           | FP/Ref1        | Flying Pizza Ltd |
+            | 2017-12-22 | 1800.00 |             | 09           | FP/Ref1        | Flying Pizza Ltd |
+            | 2017-12-08 | 600.00  | 38          | 0            | FP/Ref2        | Flying Pizza Ltd |
+            | 2017-08-31 | 5000.00 |             | 05           | FP/Ref1        | Flying Pizza Ltd |
 
-        When the Income Proving v2 TM Family API is invoked with the following:
-            | NINO                    | PL327678A  |
+        When the Income Proving v3 TM Family API is invoked with the following:
+            | NINO - Applicant        | PL327678A  |
             | Application Raised Date | 2018-01-31 |
 
         Then The Income Proving TM Family API provides the following result:
-            | HTTP Status               | 200              |
-            | Category                  | A                |
-            | Financial requirement met | true             |
-            | Application Raised date   | 2018-01-31       |
-            | National Insurance Number | PL327678A        |
-            | Threshold                 | £24800           |
-            | Employer Name             | Flying Pizza Ltd |
+            | HTTP Response           | HTTP Status               | 200              |
+            | Category A Non Salaried | Financial requirement met | true             |
+            | Category A Non Salaried | Application Raised date   | 2018-01-31       |
+            | Category A Non Salaried | National Insurance Number | PL327678A        |
+            | Category A Non Salaried | Threshold                 | £24800           |
+            | Category A Non Salaried | Employer Name             | Flying Pizza Ltd |
 
 ############
 
     Scenario: 09 Geraldine has no dependents. Her income history shows payments in 6 months but does not meet the threshold until it is supplemented by a partners income. Assessment range 2018-04-30 to 2017-10-30.
 
         Given HMRC has the following income records:
-            | Date       | Amount  | PAYE Reference | Employer         |
-            | 2018-04-27 | 1000.00 | FP/Ref1        | Flying Pizza Ltd |
-            | 2018-03-29 | 1000.00 | FP/Ref1        | Flying Pizza Ltd |
-            | 2018-02-28 | 1000.00 | FP/Ref1        | Flying Pizza Ltd |
-            | 2018-01-31 | 1000.00 | FP/Ref1        | Flying Pizza Ltd |
-            | 2017-12-29 | 1000.00 | FP/Ref1        | Flying Pizza Ltd |
-            | 2017-11-30 | 1000.00 | FP/Ref1        | Flying Pizza Ltd |
+            | Date       | Amount  | Week Number | Month Number | PAYE Reference | Employer         |
+            | 2018-04-27 | 1000.00 |             | 01           | FP/Ref1        | Flying Pizza Ltd |
+            | 2018-03-29 | 1000.00 |             | 12           | FP/Ref1        | Flying Pizza Ltd |
+            | 2018-02-28 | 1000.00 |             | 11           | FP/Ref1        | Flying Pizza Ltd |
+            | 2018-01-31 | 1000.00 |             | 10           | FP/Ref1        | Flying Pizza Ltd |
+            | 2017-12-29 | 1000.00 |             | 09           | FP/Ref1        | Flying Pizza Ltd |
+            | 2017-11-30 | 1000.00 |             | 08           | FP/Ref1        | Flying Pizza Ltd |
 
         And the applicants partner has the following income records:
-            | Date       | Amount  | PAYE Reference | Employer         |
-            | 2018-04-26 | 1000.00 | HO/Ref9        | The Home Office  |
-            | 2018-03-28 | 1000.00 | HO/Ref9        | The Home Office  |
-            | 2018-02-28 | 1000.00 | HO/Ref9        | The Home Office  |
-            | 2018-01-31 |  100.00 | HO/Ref9        | The Home Office  |
-            | 2017-12-27 |  100.00 | HO/Ref9        | The Home Office  |
-            | 2017-11-26 |  100.00 | HO/Ref9        | The Home Office  |
+            | Date       | Amount  | Week Number | Month Number | PAYE Reference | Employer        |
+            | 2018-04-26 | 1000.00 |             | 01           | HO/Ref9        | The Home Office |
+            | 2018-03-28 | 1000.00 |             | 12           | HO/Ref9        | The Home Office |
+            | 2018-02-28 | 1000.00 |             | 11           | HO/Ref9        | The Home Office |
+            | 2018-01-31 | 100.00  |             | 10           | HO/Ref9        | The Home Office |
+            | 2017-12-27 | 100.00  |             | 09           | HO/Ref9        | The Home Office |
+            | 2017-11-26 | 100.00  |             | 08           | HO/Ref9        | The Home Office |
 
-        When the Income Proving v2 TM Family API is invoked with the following:
-            | NINO - Applicant        | QS317678A  |
-            | NINO - Partner          | GF374820B  |
+        When the Income Proving v3 TM Family API is invoked with the following:
+            | NINO - Applicant        | SS317678A  |
+            | NINO - Partner          | GG374820B  |
             | Application Raised Date | 2018-04-30 |
 
         Then The Income Proving TM Family API provides the following result:
-            | HTTP Status               | 200                               |
-            | Category                  | A                                 |
-            | Financial requirement met | true                              |
-            | Application Raised date   | 2018-04-30                        |
-            | National Insurance Number | QS317678A                         |
-            | National Insurance Number | GF374820B                         |
-            | Threshold                 | 18600                             |
-            | Employer Name             | Flying Pizza Ltd, The Home Office |
+            | HTTP Response           | HTTP Status               | 200                               |
+            | Category A Non Salaried | Financial requirement met | true                              |
+            | Category A Non Salaried | Application Raised date   | 2018-04-30                        |
+            | Category A Non Salaried | National Insurance Number | SS317678A                         |
+            | Category A Non Salaried | National Insurance Number | GG374820B                         |
+            | Category A Non Salaried | Threshold                 | 18600                             |
+            | Category A Non Salaried | Employer Name             | Flying Pizza Ltd, The Home Office |
 
 
 ############
@@ -255,30 +248,29 @@ Feature: Category A Financial Requirement - Solo & Combined Applications for Non
     Scenario: 10 Bertie has no dependents. His income history shows payments but with some months having gaps. The payments do not meet the threshold until it is supplemented by a partners income also having gaps. Assessment range 2018-04-30 to 2017-10-30.
 
         Given HMRC has the following income records:
-            | Date       | Amount  | PAYE Reference | Employer         |
-            | 2018-04-27 | 2449.50 | FP/Ref1        | Flying Pizza Ltd |
-            | 2018-02-28 |  550.50 | FP/Ref1        | Flying Pizza Ltd |
-            | 2018-01-31 | 1000.00 | FP/Ref1        | Flying Pizza Ltd |
-            | 2017-11-30 | 1000.00 | FP/Ref1        | Flying Pizza Ltd |
+            | Date       | Amount  | Week Number | Month Number | PAYE Reference | Employer         |
+            | 2018-04-27 | 2449.50 |             | 01           | FP/Ref1        | Flying Pizza Ltd |
+            | 2018-02-28 | 550.50  |             | 11           | FP/Ref1        | Flying Pizza Ltd |
+            | 2018-01-31 | 1000.00 |             | 10           | FP/Ref1        | Flying Pizza Ltd |
+            | 2017-11-30 | 1000.00 |             | 08           | FP/Ref1        | Flying Pizza Ltd |
 
         And the applicants partner has the following income records:
-            | Date       | Amount  | PAYE Reference | Employer         |
-            | 2018-03-28 | 1000.00 | HO/Ref9        | The Home Office  |
-            | 2018-02-28 | 1000.00 | HO/Ref9        | The Home Office  |
-            | 2018-01-31 | 2000.00 | HO/Ref9        | The Home Office  |
-            | 2017-11-28 |  300.00 | HO/Ref9        | The Home Office  |
+            | Date       | Amount  | Week Number | Month Number | PAYE Reference | Employer        |
+            | 2018-03-28 | 1000.00 |             | 12           | HO/Ref9        | The Home Office |
+            | 2018-02-28 | 1000.00 |             | 11           | HO/Ref9        | The Home Office |
+            | 2018-01-31 | 2000.00 |             | 10           | HO/Ref9        | The Home Office |
+            | 2017-11-28 | 300.00  |             | 08           | HO/Ref9        | The Home Office |
 
-        When the Income Proving v2 TM Family API is invoked with the following:
-            | NINO - Applicant        | JD345678A  |
+        When the Income Proving v3 TM Family API is invoked with the following:
+            | NINO - Applicant        | JR345678A  |
             | NINO - Partner          | GH428174C  |
             | Application Raised Date | 2018-04-30 |
 
         Then The Income Proving TM Family API provides the following result:
-            | HTTP Status               | 200                               |
-            | Category                  | A                                 |
-            | Financial requirement met | true                              |
-            | Application Raised date   | 2018-04-30                        |
-            | National Insurance Number | JD345678A                         |
-            | National Insurance Number | GH428174C                         |
-            | Threshold                 | 18600                             |
-            | Employer Name             | Flying Pizza Ltd, The Home Office |
+            | HTTP Response           | HTTP Status               | 200                               |
+            | Category A Non Salaried | Financial requirement met | true                              |
+            | Category A Non Salaried | Application Raised date   | 2018-04-30                        |
+            | Category A Non Salaried | National Insurance Number | JR345678A                         |
+            | Category A Non Salaried | National Insurance Number | GH428174C                         |
+            | Category A Non Salaried | Threshold                 | 18600                             |
+            | Category A Non Salaried | Employer Name             | Flying Pizza Ltd, The Home Office |

--- a/src/test/specs/API-v3-wip/02 - Category A NOT PASS - Solo & Combined (Non-Salaried).feature
+++ b/src/test/specs/API-v3-wip/02 - Category A NOT PASS - Solo & Combined (Non-Salaried).feature
@@ -12,16 +12,16 @@ Feature: Category A Financial Requirement - Solo & Combined Applications
     Scenario: 01 Cheryl has no dependents. Her income history shows payments in 6 months that do not meet the threshold. Assessment range 2018-04-30 to 2017-10-30
 
         Given HMRC has the following income records:
-            | Date       | Amount  | PAYE Reference | Employer         |
-            | 2018-04-27 | 1000.00 | FP/Ref1        | Flying Pizza Ltd |
-            | 2018-03-29 | 2000.00 | FP/Ref1        | Flying Pizza Ltd |
-            | 2018-02-28 | 2000.00 | FP/Ref1        | Flying Pizza Ltd |
-            | 2018-01-31 | 2000.00 | FP/Ref1        | Flying Pizza Ltd |
-            | 2017-12-29 | 1299.50 | FP/Ref1        | Flying Pizza Ltd |
-            | 2017-11-30 | 1000.00 | FP/Ref1        | Flying Pizza Ltd |
+            | Date       | Amount  | Week Number | Month Number | PAYE Reference | Employer         |
+            | 2018-04-27 | 1000.00 |             | 01           | FP/Ref1        | Flying Pizza Ltd |
+            | 2018-03-29 | 2000.00 |             | 12           | FP/Ref1        | Flying Pizza Ltd |
+            | 2018-02-28 | 2000.00 |             | 11           | FP/Ref1        | Flying Pizza Ltd |
+            | 2018-01-31 | 2000.00 |             | 10           | FP/Ref1        | Flying Pizza Ltd |
+            | 2017-12-29 | 1299.50 |             | 09           | FP/Ref1        | Flying Pizza Ltd |
+            | 2017-11-30 | 1000.00 |             | 08           | FP/Ref1        | Flying Pizza Ltd |
 
-        When the Income Proving v2 TM Family API is invoked with the following:
-            | NINO                    | VY348368A  |
+        When the Income Proving v3 TM Family API is invoked with the following:
+            | NINO - Applicant        | AA345678A  |
             | Application Raised Date | 2018-04-30 |
 
         Then The Income Proving TM Family API provides the following result:
@@ -29,7 +29,7 @@ Feature: Category A Financial Requirement - Solo & Combined Applications
             | Financial requirement met | false            |
             | Failure Reason            | Below Threshold  |
             | Application Raised date   | 2018-04-30       |
-            | National Insurance Number | VY348368A        |
+            | National Insurance Number | AA345678A        |
             | Threshold                 | 18600            |
             | Employer Name             | Flying Pizza Ltd |
 
@@ -38,17 +38,17 @@ Feature: Category A Financial Requirement - Solo & Combined Applications
     Scenario: 02 Ashley has one dependent. His income history shows payments in 7 months that do not meet the threshold. Assessment range 2018-04-30 to 2017-10-30
 
         Given HMRC has the following income records:
-            | Date       | Amount  | PAYE Reference | Employer         |
-            | 2018-04-30 |  500.00 | FP/Ref1        | Flying Pizza Ltd |
-            | 2018-03-29 | 2000.00 | FP/Ref1        | Flying Pizza Ltd |
-            | 2018-02-28 | 4000.00 | FP/Ref1        | Flying Pizza Ltd |
-            | 2018-01-31 | 2000.00 | FP/Ref1        | Flying Pizza Ltd |
-            | 2017-12-29 | 1199.50 | FP/Ref1        | Flying Pizza Ltd |
-            | 2017-11-30 | 1000.00 | FP/Ref1        | Flying Pizza Ltd |
-            | 2017-10-30 |  500.00 | FP/Ref1        | Flying Pizza Ltd |
+            | Date       | Amount  | Week Number | Month Number | PAYE Reference | Employer         |
+            | 2018-04-30 | 500.00  |             | 01           | FP/Ref1        | Flying Pizza Ltd |
+            | 2018-03-29 | 2000.00 |             | 12           | FP/Ref1        | Flying Pizza Ltd |
+            | 2018-02-28 | 4000.00 |             | 11           | FP/Ref1        | Flying Pizza Ltd |
+            | 2018-01-31 | 2000.00 |             | 10           | FP/Ref1        | Flying Pizza Ltd |
+            | 2017-12-29 | 1199.50 |             | 09           | FP/Ref1        | Flying Pizza Ltd |
+            | 2017-11-30 | 1000.00 |             | 08           | FP/Ref1        | Flying Pizza Ltd |
+            | 2017-10-30 | 500.00  |             | 07           | FP/Ref1        | Flying Pizza Ltd |
 
-        When the Income Proving v2 TM Family API is invoked with the following:
-            | NINO                    | VB345624B  |
+        When the Income Proving v3 TM Family API is invoked with the following:
+            | NINO - Applicant        | AA345678A  |
             | Application Raised Date | 2018-04-30 |
 
         Then The Income Proving TM Family API provides the following result:
@@ -56,7 +56,7 @@ Feature: Category A Financial Requirement - Solo & Combined Applications
             | Financial requirement met | false            |
             | Failure Reason            | Below Threshold  |
             | Application Raised date   | 2018-04-30       |
-            | National Insurance Number | VB345624B        |
+            | National Insurance Number | AA345678A        |
             | Threshold                 | 22400            |
             | Employer Name             | Flying Pizza Ltd |
 
@@ -65,17 +65,17 @@ Feature: Category A Financial Requirement - Solo & Combined Applications
     Scenario: 03 Carla has no dependents. Her income history shows payments in 7 months that meet the threshold however one payment is just outside the assessment range. Assessment range 2018-04-30 to 2017-10-30
 
         Given HMRC has the following income records:
-            | Date       | Amount  | PAYE Reference | Employer         |
-            | 2018-04-30 | 2000.00 | FP/Ref1        | Flying Pizza Ltd |
-            | 2018-03-29 | 2000.00 | FP/Ref1        | Flying Pizza Ltd |
-            | 2018-02-28 | 2000.00 | FP/Ref1        | Flying Pizza Ltd |
-            | 2017-01-31 | 1300.00 | FP/Ref1        | Flying Pizza Ltd |
-            | 2017-12-29 | 1000.00 | FP/Ref1        | Flying Pizza Ltd |
-            | 2017-11-30 |  999.99 | FP/Ref1        | Flying Pizza Ltd |
-            | 2017-10-29 |  000.01 | FP/Ref1        | Flying Pizza Ltd |
+            | Date       | Amount  | Week Number | Month Number | PAYE Reference | Employer         |
+            | 2018-04-30 | 2000.00 |             | 01           | FP/Ref1        | Flying Pizza Ltd |
+            | 2018-03-29 | 2000.00 |             | 12           | FP/Ref1        | Flying Pizza Ltd |
+            | 2018-02-28 | 2000.00 |             | 11           | FP/Ref1        | Flying Pizza Ltd |
+            | 2017-01-31 | 1300.00 |             | 10           | FP/Ref1        | Flying Pizza Ltd |
+            | 2017-12-29 | 1000.00 |             | 09           | FP/Ref1        | Flying Pizza Ltd |
+            | 2017-11-30 | 999.99  |             | 08           | FP/Ref1        | Flying Pizza Ltd |
+            | 2017-10-29 | 000.01  |             | 08           | FP/Ref1        | Flying Pizza Ltd |
 
-        When the Income Proving v2 TM Family API is invoked with the following:
-            | NINO                    | FD345678A  |
+        When the Income Proving v3 TM Family API is invoked with the following:
+            | NINO - Applicant        | AA345678A  |
             | Application Raised Date | 2018-04-30 |
 
         Then The Income Proving TM Family API provides the following result:
@@ -84,7 +84,7 @@ Feature: Category A Financial Requirement - Solo & Combined Applications
             | Financial requirement met | false            |
             | Failure Reason            | Below Threshold  |
             | Application Raised date   | 2018-04-30       |
-            | National Insurance Number | FD345678A        |
+            | National Insurance Number | AA345678A        |
             | Threshold                 | 18600            |
             | Employer Name             | Flying Pizza Ltd |
 
@@ -93,17 +93,17 @@ Feature: Category A Financial Requirement - Solo & Combined Applications
     Scenario: 04 Kayleigh has no dependants. Her income history shows payments that only meet the threshold with combined income from multiple employers. Assessment range 2018-04-30 to 2017-10-30
 
         Given HMRC has the following income records:
-            | Date       | Amount  | PAYE Reference | Employer          |
-            | 2018-03-29 | 2000.00 | FP/Ref1        | Flying Pizza Ltd  |
-            | 2018-02-28 | 2000.00 | FP/Ref1        | Flying Pizza Ltd  |
-            | 2018-01-31 | 2000.00 | FP/Ref1        | Flying Pizza Ltd  |
-            | 2017-12-29 | 2000.00 | FP/Ref2        | Derek's Autos Ltd |
-            | 2017-11-30 | 1000.00 | FP/Ref1        | Flying Pizza Ltd  |
-            | 2017-10-30 | 1000.00 | FP/Ref1        | Flying Pizza Ltd  |
+            | Date       | Amount  | Week Number | Month Number | PAYE Reference | Employer          |
+            | 2018-03-29 | 2000.00 |             | 01           | FP/Ref1        | Flying Pizza Ltd  |
+            | 2018-02-28 | 2000.00 |             | 12           | FP/Ref1        | Flying Pizza Ltd  |
+            | 2018-01-31 | 2000.00 |             | 11           | FP/Ref1        | Flying Pizza Ltd  |
+            | 2017-12-29 | 2000.00 |             | 10           | FP/Ref2        | Derek's Autos Ltd |
+            | 2017-11-30 | 1000.00 |             | 09           | FP/Ref1        | Flying Pizza Ltd  |
+            | 2017-10-30 | 1000.00 |             | 08           | FP/Ref1        | Flying Pizza Ltd  |
 
 
-        When the Income Proving v2 TM Family API is invoked with the following:
-            | NINO                    | KS379678A  |
+        When the Income Proving v3 TM Family API is invoked with the following:
+            | NINO - Applicant        | AA345678A  |
             | Application Raised Date | 2018-04-30 |
 
         Then The Income Proving TM Family API provides the following result:
@@ -111,7 +111,7 @@ Feature: Category A Financial Requirement - Solo & Combined Applications
             | Financial requirement met | false                               |
             | Failure Reason            | Multiple Employers                  |
             | Application Raised date   | 2018-04-30                          |
-            | National Insurance Number | KS379678A                           |
+            | National Insurance Number | AA345678A                           |
             | Threshold                 | 18600                               |
             | Employer Name             | Flying Pizza Ltd, Derek's Autos Ltd |
 
@@ -120,22 +120,22 @@ Feature: Category A Financial Requirement - Solo & Combined Applications
     Scenario: 05 Barry has no dependents. His income history shows a payment in some months with gaps but do not meet the threshold even when it is supplemented by a partners income also having gaps. Assessment range 2018-04-30 to 2017-10-30
 
         Given HMRC has the following income records:
-            | Date       | Amount  | PAYE Reference | Employer         |
-            | 2018-04-27 | 2450.00 | FP/Ref1        | Flying Pizza Ltd |
-            | 2018-02-28 |  550.00 | FP/Ref1        | Flying Pizza Ltd |
-            | 2018-01-31 | 1000.00 | FP/Ref1        | Flying Pizza Ltd |
-            | 2017-11-30 | 1000.00 | FP/Ref1        | Flying Pizza Ltd |
+            | Date       | Amount  | Week Number | Month Number | PAYE Reference | Employer         |
+            | 2018-04-27 | 2450.00 |             | 01           | FP/Ref1        | Flying Pizza Ltd |
+            | 2018-02-28 | 550.00  |             | 12           | FP/Ref1        | Flying Pizza Ltd |
+            | 2018-01-31 | 1000.00 |             | 11           | FP/Ref1        | Flying Pizza Ltd |
+            | 2017-11-30 | 1000.00 |             | 10           | FP/Ref1        | Flying Pizza Ltd |
 
         And the applicants partner has the following income records:
-            | Date       | Amount  | PAYE Reference | Employer         |
-            | 2018-04-27 | 1000.00 | HO/Ref9        | The Home Office  |
-            | 2018-02-28 | 1000.00 | HO/Ref9        | The Home Office  |
-            | 2018-01-31 | 2000.00 | HO/Ref9        | The Home Office  |
-            | 2017-12-23 |  299.99 | HO/Ref9        | The Home Office  |
+            | Date       | Amount  | Week Number | Month Number | PAYE Reference | Employer        |
+            | 2018-04-27 | 1000.00 |             | 01           | HO/Ref9        | The Home Office |
+            | 2018-02-28 | 1000.00 |             | 12           | HO/Ref9        | The Home Office |
+            | 2018-01-31 | 2000.00 |             | 11           | HO/Ref9        | The Home Office |
+            | 2017-12-23 | 299.99  |             | 10           | HO/Ref9        | The Home Office |
 
-        When the Income Proving v2 TM Family API is invoked with the following:
-            | NINO - Applicant        | AC345118A  |
-            | NINO - Partner          | SC382638G  |
+        When the Income Proving v3 TM Family API is invoked with the following:
+            | NINO - Applicant        | AA345678A  |
+            | NINO - Partner          | GE345678A  |
             | Application Raised Date | 2018-04-30 |
 
         Then The Income Proving TM Family API provides the following result:
@@ -143,8 +143,8 @@ Feature: Category A Financial Requirement - Solo & Combined Applications
             | Financial requirement met | false            |
             | Failure Reason            | Below Threshold  |
             | Application Raised date   | 2018-04-30       |
-            | National Insurance Number | AC345118A        |
-            | National Insurance Number | SC382638G        |
+            | National Insurance Number | AA345678A        |
+            | National Insurance Number | GE345678A        |
             | Threshold                 | 18600            |
             | Employer Name             | Flying Pizza Ltd |
 
@@ -153,22 +153,22 @@ Feature: Category A Financial Requirement - Solo & Combined Applications
     Scenario: 06 Sherilyn has two dependents. Her income history shows a full contingent of payments over a 12 month period. All 12 months average as a pass against the threshold but the payments within the 6 month period do not. Assessment range 2018-04-30 to 2017-10-30
 
         Given HMRC has the following income records:
-            | Date       | Amount  | PAYE Reference | Employer         |
-            | 2018-04-27 | 400.00  | FP/Ref1        | Flying Pizza Ltd |
-            | 2018-03-29 | 300.00  | FP/Ref1        | Flying Pizza Ltd |
-            | 2018-02-23 | 300.00  | FP/Ref1        | Flying Pizza Ltd |
-            | 2018-01-26 | 300.00  | FP/Ref1        | Flying Pizza Ltd |
-            | 2017-12-27 |  50.00  | FP/Ref1        | Flying Pizza Ltd |
-            | 2017-11-28 |  49.99  | FP/Ref1        | Flying Pizza Ltd |
-            | 2017-10-31 | 1000.00 | FP/Ref1        | Flying Pizza Ltd |
-            | 2017-09-30 | 1000.00 | FP/Ref1        | Flying Pizza Ltd |
-            | 2017-08-27 | 2500.00 | FP/Ref1        | Flying Pizza Ltd |
-            | 2017-07-28 | 1000.00 | FP/Ref1        | Flying Pizza Ltd |
-            | 2017-06-31 | 1000.00 | FP/Ref1        | Flying Pizza Ltd |
-            | 2017-05-30 | 1000.00 | FP/Ref1        | Flying Pizza Ltd |
+            | Date       | Amount  | Week Number | Month Number | PAYE Reference | Employer         |
+            | 2018-04-27 | 400.00  |             | 01           | FP/Ref1        | Flying Pizza Ltd |
+            | 2018-03-29 | 300.00  |             | 12           | FP/Ref1        | Flying Pizza Ltd |
+            | 2018-02-23 | 300.00  |             | 11           | FP/Ref1        | Flying Pizza Ltd |
+            | 2018-01-26 | 300.00  |             | 10           | FP/Ref1        | Flying Pizza Ltd |
+            | 2017-12-27 | 50.00   |             | 09           | FP/Ref1        | Flying Pizza Ltd |
+            | 2017-11-28 | 49.99   |             | 08           | FP/Ref1        | Flying Pizza Ltd |
+            | 2017-10-31 | 1000.00 |             | 07           | FP/Ref1        | Flying Pizza Ltd |
+            | 2017-09-30 | 1000.00 |             | 06           | FP/Ref1        | Flying Pizza Ltd |
+            | 2017-08-27 | 2500.00 |             | 05           | FP/Ref1        | Flying Pizza Ltd |
+            | 2017-07-28 | 1000.00 |             | 04           | FP/Ref1        | Flying Pizza Ltd |
+            | 2017-06-31 | 1000.00 |             | 03           | FP/Ref1        | Flying Pizza Ltd |
+            | 2017-05-30 | 1000.00 |             | 02           | FP/Ref1        | Flying Pizza Ltd |
 
-        When the Income Proving v2 TM Family API is invoked with the following:
-            | NINO - Applicant        | HG345118A  |
+        When the Income Proving v3 TM Family API is invoked with the following:
+            | NINO - Applicant        | GE345678A  |
             | Application Raised Date | 2018-04-30 |
 
         Then The Income Proving TM Family API provides the following result:
@@ -176,6 +176,6 @@ Feature: Category A Financial Requirement - Solo & Combined Applications
             | Financial requirement met | false            |
             | Failure Reason            | Below Threshold  |
             | Application Raised date   | 2018-04-30       |
-            | National Insurance Number | HG345118A        |
+            | National Insurance Number | GE345678A        |
             | Threshold                 | 24800            |
             | Employer Name             | Flying Pizza Ltd |


### PR DESCRIPTION
Making the layout of the Cat A Non Salaried BDD tests match the current requirements to run (more columns in tables etc.) and made all the NINOs valid so that tests run but fail (feature yet to be implemented).