### PR TITLE
Ee 3838 Further Cat A Non-Salaried BDD Tidy and fixing date-dependent test failure

### DIFF
--- a/src/test/java/uk/gov/digital/ho/proving/income/validator/CatAMonthlyIncomeValidatorTest.java
+++ b/src/test/java/uk/gov/digital/ho/proving/income/validator/CatAMonthlyIncomeValidatorTest.java
@@ -144,7 +144,7 @@ public class CatAMonthlyIncomeValidatorTest {
         LocalDate raisedDate = LocalDate.now();
         List<ApplicantIncome> incomes = getConsecutiveIncomesWithDifferentMonthlyPayDay2(raisedDate);
 
-        IncomeValidationRequest request = new IncomeValidationRequest(incomes, raisedDate, 0);
+        IncomeValidationRequest request = new IncomeValidationRequest(incomes, raisedDate.withDayOfMonth(16), 0);
         IncomeValidationResult categoryAIndividual = validator.validate(request);
 
         assertThat(categoryAIndividual.status()).isEqualTo(IncomeValidationStatus.MONTHLY_SALARIED_PASSED);
@@ -156,7 +156,7 @@ public class CatAMonthlyIncomeValidatorTest {
         LocalDate raisedDate = LocalDate.now();
         List<ApplicantIncome> incomes = getConsecutiveIncomesWithExactlyTheAmount2(raisedDate);
 
-        IncomeValidationRequest request = new IncomeValidationRequest(incomes, raisedDate, 0);
+        IncomeValidationRequest request = new IncomeValidationRequest(incomes, raisedDate.withDayOfMonth(17), 0);
         IncomeValidationResult categoryAIndividual = validator.validate(request);
 
         assertThat(categoryAIndividual.status()).isEqualTo(IncomeValidationStatus.MONTHLY_SALARIED_PASSED);

--- a/src/test/specs/API-v3-wip/01 - Category A PASS - Solo & Combined (Non-Salaried).feature
+++ b/src/test/specs/API-v3-wip/01 - Category A PASS - Solo & Combined (Non-Salaried).feature
@@ -30,12 +30,10 @@ Feature: Category A Financial Requirement - Solo & Combined Applications for Non
         Then The Income Proving TM Family API provides the following result:
             | HTTP Response           | HTTP Status               | 200              |
             | Applicant               | National Insurance Number | AA345678A        |
-            | Category A Non Salaried | Category                  | A                |
             | Category A Non Salaried | Financial requirement met | true             |
             | Category A Non Salaried | Application Raised date   | 2018-04-30       |
-            | Category A Non Salaried | National Insurance Number | AA345678A        |
             | Category A Non Salaried | Threshold                 | 18600            |
-            | Category A Non Salaried | Employer Name             | Flying Pizza Ltd |
+            | Category A Non Salaried | Employer Name - AA345678A | Flying Pizza Ltd |
 
 ############
 
@@ -46,7 +44,7 @@ Feature: Category A Financial Requirement - Solo & Combined Applications for Non
             | 2018-04-30 | 2000.00 |             | 01           | FP/Ref1        | Flying Pizza Ltd |
             | 2018-03-29 | 2000.00 |             | 12           | FP/Ref1        | Flying Pizza Ltd |
             | 2018-02-28 | 2000.00 |             | 11           | FP/Ref1        | Flying Pizza Ltd |
-            | 2017-01-31 | 1300.00 |             | 10           | FP/Ref1        | Flying Pizza Ltd |
+            | 2018-01-31 | 1300.00 |             | 10           | FP/Ref1        | Flying Pizza Ltd |
             | 2017-12-29 | 1000.00 |             | 09           | FP/Ref1        | Flying Pizza Ltd |
             | 2017-11-30 | 500.00  |             | 08           | FP/Ref1        | Flying Pizza Ltd |
             | 2017-10-30 | 500.00  |             | 07           | FP/Ref1        | Flying Pizza Ltd |
@@ -59,9 +57,9 @@ Feature: Category A Financial Requirement - Solo & Combined Applications for Non
             | HTTP Response           | HTTP Status               | 200              |
             | Category A Non Salaried | Financial requirement met | true             |
             | Category A Non Salaried | Application Raised date   | 2018-04-30       |
-            | Category A Non Salaried | National Insurance Number | GE345678A        |
+            | Applicant               | National Insurance Number | GE345678A        |
             | Category A Non Salaried | Threshold                 | 18600            |
-            | Category A Non Salaried | Employer Name             | Flying Pizza Ltd |
+            | Category A Non Salaried | Employer Name - GE345678A | Flying Pizza Ltd |
 
 ############
 
@@ -85,9 +83,9 @@ Feature: Category A Financial Requirement - Solo & Combined Applications for Non
             | HTTP Response           | HTTP Status               | 200                              |
             | Category A Non Salaried | Financial requirement met | true                             |
             | Category A Non Salaried | Application Raised date   | 2018-04-30                       |
-            | Category A Non Salaried | National Insurance Number | EB345678A                        |
+            | Applicant               | National Insurance Number | EB345678A                        |
             | Category A Non Salaried | Threshold                 | 18600                            |
-            | Category A Non Salaried | Employer Name             | Flying Pizza Ltd, Flowers 4U Ltd |
+            | Category A Non Salaried | Employer Name - EB345678A | Flying Pizza Ltd, Flowers 4U Ltd |
 
 ############
 
@@ -106,9 +104,9 @@ Feature: Category A Financial Requirement - Solo & Combined Applications for Non
             | HTTP Response           | HTTP Status               | 200              |
             | Category A Non Salaried | Financial requirement met | true             |
             | Category A Non Salaried | Application Raised date   | 2017-12-30       |
-            | Category A Non Salaried | National Insurance Number | JH573849A        |
+            | Applicant               | National Insurance Number | JH573849A        |
             | Category A Non Salaried | Threshold                 | 18600            |
-            | Category A Non Salaried | Employer Name             | Flying Pizza Ltd |
+            | Category A Non Salaried | Employer Name - JH573849A | Flying Pizza Ltd |
 
 ############
 
@@ -127,9 +125,9 @@ Feature: Category A Financial Requirement - Solo & Combined Applications for Non
             | HTTP Response           | HTTP Status               | 200              |
             | Category A Non Salaried | Financial requirement met | true             |
             | Category A Non Salaried | Application Raised date   | 2017-12-30       |
-            | Category A Non Salaried | National Insurance Number | KL927581A        |
+            | Applicant               | National Insurance Number | KL927581A        |
             | Category A Non Salaried | Threshold                 | 18600            |
-            | Category A Non Salaried | Employer Name             | Flying Pizza Ltd |
+            | Category A Non Salaried | Employer Name - KL927581A | Flying Pizza Ltd |
 
 ############
 
@@ -140,13 +138,13 @@ Feature: Category A Financial Requirement - Solo & Combined Applications for Non
             | 2017-09-29 | 2000.00 |             | 01           | FP/Ref1        | Flying Pizza Ltd |
             | 2017-08-25 | 2000.00 |             | 12           | FP/Ref1        | Flying Pizza Ltd |
             | 2017-07-28 | 2000.00 |             | 11           | FP/Ref1        | Flying Pizza Ltd |
-            | 2017-06-30 | 325.00  |             | 10           | FP/Ref2        | Flying Pizza Ltd |
-            | 2017-06-23 | 325.00  |             | 09           | FP/Ref2        | Flying Pizza Ltd |
-            | 2017-06-16 | 325.00  |             | 08           | FP/Ref2        | Flying Pizza Ltd |
-            | 2017-06-09 | 325.00  |             | 07           | FP/Ref2        | Flying Pizza Ltd |
+            | 2017-06-30 | 325.00  |             | 10           | FP/Ref1        | Flying Pizza Ltd |
+            | 2017-06-23 | 325.00  |             | 09           | FP/Ref1        | Flying Pizza Ltd |
+            | 2017-06-16 | 325.00  |             | 08           | FP/Ref1        | Flying Pizza Ltd |
+            | 2017-06-09 | 325.00  |             | 07           | FP/Ref1        | Flying Pizza Ltd |
             | 2017-05-26 | 1000.00 |             | 06           | FP/Ref1        | Flying Pizza Ltd |
             | 2017-04-28 | 500.00  |             | 05           | FP/Ref1        | Flying Pizza Ltd |
-            | 2017-04-07 | 500.00  | 03          |              | FP/Ref2        | Flying Pizza Ltd |
+            | 2017-04-07 | 500.00  | 03          |              | FP/Ref1        | Flying Pizza Ltd |
 
         When the Income Proving v3 TM Family API is invoked with the following:
             | NINO - Applicant        | AB889357A  |
@@ -156,9 +154,9 @@ Feature: Category A Financial Requirement - Solo & Combined Applications for Non
             | HTTP Response           | HTTP Status               | 200              |
             | Category A Non Salaried | Financial requirement met | true             |
             | Category A Non Salaried | Application Raised date   | 2017-09-30       |
-            | Category A Non Salaried | National Insurance Number | AAB889357A       |
+            | Applicant               | National Insurance Number | AB889357A        |
             | Category A Non Salaried | Threshold                 | 18600            |
-            | Category A Non Salaried | Employer Name             | Flying Pizza Ltd |
+            | Category A Non Salaried | Employer Name - AB889357A | Flying Pizza Ltd |
 
 ############
 
@@ -174,14 +172,15 @@ Feature: Category A Financial Requirement - Solo & Combined Applications for Non
         When the Income Proving v3 TM Family API is invoked with the following:
             | NINO - Applicant        | LA345628A  |
             | Application Raised Date | 2018-01-31 |
+            | Dependants              | 1          |
 
         Then The Income Proving TM Family API provides the following result:
             | HTTP Response           | HTTP Status               | 200              |
             | Category A Non Salaried | Financial requirement met | true             |
             | Category A Non Salaried | Application Raised date   | 2018-01-31       |
-            | Category A Non Salaried | National Insurance Number | LA345628A        |
-            | Category A Non Salaried | Threshold                 | £22400           |
-            | Category A Non Salaried | Employer Name             | Flying Pizza Ltd |
+            | Applicant               | National Insurance Number | LA345628A        |
+            | Category A Non Salaried | Threshold                 | 22400            |
+            | Category A Non Salaried | Employer Name - LA345628A | Flying Pizza Ltd |
 
 ############
 
@@ -191,20 +190,21 @@ Feature: Category A Financial Requirement - Solo & Combined Applications for Non
             | Date       | Amount  | Week Number | Month Number | PAYE Reference | Employer         |
             | 2018-01-26 | 5000.00 |             | 10           | FP/Ref1        | Flying Pizza Ltd |
             | 2017-12-22 | 1800.00 |             | 09           | FP/Ref1        | Flying Pizza Ltd |
-            | 2017-12-08 | 600.00  | 38          | 0            | FP/Ref2        | Flying Pizza Ltd |
+            | 2017-12-08 | 600.00  | 38          |              | FP/Ref1        | Flying Pizza Ltd |
             | 2017-08-31 | 5000.00 |             | 05           | FP/Ref1        | Flying Pizza Ltd |
 
         When the Income Proving v3 TM Family API is invoked with the following:
             | NINO - Applicant        | PL327678A  |
             | Application Raised Date | 2018-01-31 |
+            | Dependants              | 2          |
 
         Then The Income Proving TM Family API provides the following result:
             | HTTP Response           | HTTP Status               | 200              |
             | Category A Non Salaried | Financial requirement met | true             |
             | Category A Non Salaried | Application Raised date   | 2018-01-31       |
-            | Category A Non Salaried | National Insurance Number | PL327678A        |
-            | Category A Non Salaried | Threshold                 | £24800           |
-            | Category A Non Salaried | Employer Name             | Flying Pizza Ltd |
+            | Applicant               | National Insurance Number | PL327678A        |
+            | Category A Non Salaried | Threshold                 | 24800            |
+            | Category A Non Salaried | Employer Name - PL327678A | Flying Pizza Ltd |
 
 ############
 
@@ -234,13 +234,14 @@ Feature: Category A Financial Requirement - Solo & Combined Applications for Non
             | Application Raised Date | 2018-04-30 |
 
         Then The Income Proving TM Family API provides the following result:
-            | HTTP Response           | HTTP Status               | 200                               |
-            | Category A Non Salaried | Financial requirement met | true                              |
-            | Category A Non Salaried | Application Raised date   | 2018-04-30                        |
-            | Category A Non Salaried | National Insurance Number | SS317678A                         |
-            | Category A Non Salaried | National Insurance Number | GG374820B                         |
-            | Category A Non Salaried | Threshold                 | 18600                             |
-            | Category A Non Salaried | Employer Name             | Flying Pizza Ltd, The Home Office |
+            | HTTP Response           | HTTP Status               | 200              |
+            | Category A Non Salaried | Financial requirement met | true             |
+            | Category A Non Salaried | Application Raised date   | 2018-04-30       |
+            | Applicant               | National Insurance Number | SS317678A        |
+            | Partner                 | National Insurance Number | GG374820B        |
+            | Category A Non Salaried | Threshold                 | 18600            |
+            | Category A Non Salaried | Employer Name - SS317678A | Flying Pizza Ltd |
+            | Category A Non Salaried | Employer Name - GG374820B | The Home Office  |
 
 
 ############
@@ -267,10 +268,11 @@ Feature: Category A Financial Requirement - Solo & Combined Applications for Non
             | Application Raised Date | 2018-04-30 |
 
         Then The Income Proving TM Family API provides the following result:
-            | HTTP Response           | HTTP Status               | 200                               |
-            | Category A Non Salaried | Financial requirement met | true                              |
-            | Category A Non Salaried | Application Raised date   | 2018-04-30                        |
-            | Category A Non Salaried | National Insurance Number | JR345678A                         |
-            | Category A Non Salaried | National Insurance Number | GH428174C                         |
-            | Category A Non Salaried | Threshold                 | 18600                             |
-            | Category A Non Salaried | Employer Name             | Flying Pizza Ltd, The Home Office |
+            | HTTP Response           | HTTP Status               | 200              |
+            | Category A Non Salaried | Financial requirement met | true             |
+            | Category A Non Salaried | Application Raised date   | 2018-04-30       |
+            | Applicant               | National Insurance Number | JR345678A        |
+            | Partner                 | National Insurance Number | GH428174C        |
+            | Category A Non Salaried | Threshold                 | 18600            |
+            | Category A Non Salaried | Employer Name - JR345678A | Flying Pizza Ltd |
+            | Category A Non Salaried | Employer Name - GH428174C | The Home Office  |

--- a/src/test/specs/API-v3-wip/02 - Category A NOT PASS - Solo & Combined (Non-Salaried).feature
+++ b/src/test/specs/API-v3-wip/02 - Category A NOT PASS - Solo & Combined (Non-Salaried).feature
@@ -25,13 +25,13 @@ Feature: Category A Financial Requirement - Solo & Combined Applications
             | Application Raised Date | 2018-04-30 |
 
         Then The Income Proving TM Family API provides the following result:
-            | HTTP Status               | 200              |
-            | Financial requirement met | false            |
-            | Failure Reason            | Below Threshold  |
-            | Application Raised date   | 2018-04-30       |
-            | National Insurance Number | AA345678A        |
-            | Threshold                 | 18600            |
-            | Employer Name             | Flying Pizza Ltd |
+            | HTTP Response           | HTTP Status               | 200                               |
+            | Category A Non Salaried | Financial requirement met | false                             |
+            | Category A Non Salaried | Failure Reason            | CATA_NON_SALARIED_BELOW_THRESHOLD |
+            | Category A Non Salaried | Application Raised date   | 2018-04-30                        |
+            | Applicant               | National Insurance Number | AA345678A                         |
+            | Category A Non Salaried | Threshold                 | 18600                             |
+            | Category A Non Salaried | Employer Name - AA345678A | Flying Pizza Ltd                  |
 
     ############
 
@@ -50,15 +50,16 @@ Feature: Category A Financial Requirement - Solo & Combined Applications
         When the Income Proving v3 TM Family API is invoked with the following:
             | NINO - Applicant        | AA345678A  |
             | Application Raised Date | 2018-04-30 |
+            | Dependants              | 1          |
 
         Then The Income Proving TM Family API provides the following result:
-            | HTTP Status               | 200              |
-            | Financial requirement met | false            |
-            | Failure Reason            | Below Threshold  |
-            | Application Raised date   | 2018-04-30       |
-            | National Insurance Number | AA345678A        |
-            | Threshold                 | 22400            |
-            | Employer Name             | Flying Pizza Ltd |
+            | HTTP Response           | HTTP Status               | 200                               |
+            | Category A Non Salaried | Financial requirement met | false                             |
+            | Category A Non Salaried | Failure Reason            | CATA_NON_SALARIED_BELOW_THRESHOLD |
+            | Category A Non Salaried | Application Raised date   | 2018-04-30                        |
+            | Applicant               | National Insurance Number | AA345678A                         |
+            | Category A Non Salaried | Threshold                 | 22400                             |
+            | Category A Non Salaried | Employer Name - AA345678A | Flying Pizza Ltd                  |
 
        ############
 
@@ -79,14 +80,13 @@ Feature: Category A Financial Requirement - Solo & Combined Applications
             | Application Raised Date | 2018-04-30 |
 
         Then The Income Proving TM Family API provides the following result:
-            | HTTP Status               | 200              |
-            | Category                  | A                |
-            | Financial requirement met | false            |
-            | Failure Reason            | Below Threshold  |
-            | Application Raised date   | 2018-04-30       |
-            | National Insurance Number | AA345678A        |
-            | Threshold                 | 18600            |
-            | Employer Name             | Flying Pizza Ltd |
+            | HTTP Response           | HTTP Status               | 200                               |
+            | Category A Non Salaried | Financial requirement met | false                             |
+            | Category A Non Salaried | Failure Reason            | CATA_NON_SALARIED_BELOW_THRESHOLD |
+            | Category A Non Salaried | Application Raised date   | 2018-04-30                        |
+            | Applicant               | National Insurance Number | AA345678A                         |
+            | Category A Non Salaried | Threshold                 | 18600                             |
+            | Category A Non Salaried | Employer Name - AA345678A | Flying Pizza Ltd                  |
 
     ############
 
@@ -107,13 +107,13 @@ Feature: Category A Financial Requirement - Solo & Combined Applications
             | Application Raised Date | 2018-04-30 |
 
         Then The Income Proving TM Family API provides the following result:
-            | HTTP Status               | 200                                 |
-            | Financial requirement met | false                               |
-            | Failure Reason            | Multiple Employers                  |
-            | Application Raised date   | 2018-04-30                          |
-            | National Insurance Number | AA345678A                           |
-            | Threshold                 | 18600                               |
-            | Employer Name             | Flying Pizza Ltd, Derek's Autos Ltd |
+            | HTTP Response           | HTTP Status               | 200                                 |
+            | Category A Non Salaried | Financial requirement met | false                               |
+            | Category A Non Salaried | Failure Reason            | MULTIPLE_EMPLOYERS                  |
+            | Category A Non Salaried | Application Raised date   | 2018-04-30                          |
+            | Applicant               | National Insurance Number | AA345678A                           |
+            | Category A Non Salaried | Threshold                 | 18600                               |
+            | Category A Non Salaried | Employer Name - AA345678A | Flying Pizza Ltd, Derek's Autos Ltd |
 
     ############
 
@@ -139,14 +139,15 @@ Feature: Category A Financial Requirement - Solo & Combined Applications
             | Application Raised Date | 2018-04-30 |
 
         Then The Income Proving TM Family API provides the following result:
-            | HTTP Status               | 200              |
-            | Financial requirement met | false            |
-            | Failure Reason            | Below Threshold  |
-            | Application Raised date   | 2018-04-30       |
-            | National Insurance Number | AA345678A        |
-            | National Insurance Number | GE345678A        |
-            | Threshold                 | 18600            |
-            | Employer Name             | Flying Pizza Ltd |
+            | HTTP Response           | HTTP Status               | 200                               |
+            | Category A Non Salaried | Financial requirement met | false                             |
+            | Category A Non Salaried | Failure Reason            | CATA_NON_SALARIED_BELOW_THRESHOLD |
+            | Category A Non Salaried | Application Raised date   | 2018-04-30                        |
+            | Applicant               | National Insurance Number | AA345678A                         |
+            | Partner                 | National Insurance Number | GE345678A                         |
+            | Category A Non Salaried | Threshold                 | 18600                             |
+            | Category A Non Salaried | Employer Name - AA345678A | Flying Pizza Ltd                  |
+            | Category A Non Salaried | Employer Name - GE345678A | The Home Office                   |
 
     ############
 
@@ -170,12 +171,13 @@ Feature: Category A Financial Requirement - Solo & Combined Applications
         When the Income Proving v3 TM Family API is invoked with the following:
             | NINO - Applicant        | GE345678A  |
             | Application Raised Date | 2018-04-30 |
+            | Dependants              | 2          |
 
         Then The Income Proving TM Family API provides the following result:
-            | HTTP Status               | 200              |
-            | Financial requirement met | false            |
-            | Failure Reason            | Below Threshold  |
-            | Application Raised date   | 2018-04-30       |
-            | National Insurance Number | GE345678A        |
-            | Threshold                 | 24800            |
-            | Employer Name             | Flying Pizza Ltd |
+            | HTTP Response           | HTTP Status               | 200                               |
+            | Category A Non Salaried | Financial requirement met | false                             |
+            | Category A Non Salaried | Failure Reason            | CATA_NON_SALARIED_BELOW_THRESHOLD |
+            | Category A Non Salaried | Application Raised date   | 2018-04-30                        |
+            | Applicant               | National Insurance Number | GE345678A                         |
+            | Category A Non Salaried | Threshold                 | 24800                             |
+            | Category A Non Salaried | Employer Name - GE345678A | Flying Pizza Ltd                  |


### PR DESCRIPTION
More tidying/fixing of BDD tests for Category A Non-Salaried. The changes are mostly just typos and layout issues that were not addressed in earlier tidy-up.

As a unit test has started failing due to the day of the month I have fixed this. The tests were updated so that the application raised date would be "today" for whenever the tests are run. The test data for the failing test has fixed values for day of month so this is why the test started failing due to the date. To fix I've set the day of month similarly in the test.