### PR TITLE
Ee 12142 timeout properties gas

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -48,7 +48,7 @@ pipeline:
     image: plugins/git
     commands:
       - git clone https://github.com/UKHomeOffice/kube-pttg-ip-api.git
-      - git checkout -b EE-12142-proxy-timeout
+      - git checkout -b EE-12142-timeout-proxy
     when:
       event: [push, tag, deployment]
 

--- a/.drone.yml
+++ b/.drone.yml
@@ -48,7 +48,7 @@ pipeline:
     image: plugins/git
     commands:
       - git clone https://github.com/UKHomeOffice/kube-pttg-ip-api.git
-      - git checkout EE-12142-proxy-timeout
+      - git checkout -b EE-12142-proxy-timeout
     when:
       event: [push, tag, deployment]
 

--- a/.drone.yml
+++ b/.drone.yml
@@ -14,7 +14,7 @@ pipeline:
     commands:
       - docker build -t pttg-ip-api .
     when:
-      branch: [master, refs/tags/*, EE-8760-correlationId]
+      branch: [master, refs/tags/*, EE-12142-timeout-properties-gas]
       event: [push, tag]
 
   install-docker-image:
@@ -28,7 +28,7 @@ pipeline:
       - docker tag pttg-ip-api quay.io/ukhomeofficedigital/pttg-ip-api:build-$${DRONE_BUILD_NUMBER}
       - docker push quay.io/ukhomeofficedigital/pttg-ip-api:build-$${DRONE_BUILD_NUMBER}
     when:
-      branch: [master, EE-8760-correlationId]
+      branch: [master, EE-12142-timeout-properties-gas]
       event: push
 
   tag-docker-image-with-git-tag:
@@ -64,7 +64,7 @@ pipeline:
       - cd kube-pttg-ip-api
       - ./deploy.sh
     when:
-      branch: [master, EE-8760-correlationId]
+      branch: [master, EE-12142-timeout-properties-gas]
       event: [push, tag]
 
   deployment:

--- a/.drone.yml
+++ b/.drone.yml
@@ -48,7 +48,7 @@ pipeline:
     image: plugins/git
     commands:
       - git clone https://github.com/UKHomeOffice/kube-pttg-ip-api.git
-      - git checkout -b EE-12142-timeout-proxy
+      - cd kube-pttg-ip-api && git checkout -b EE-12142-timeout-proxy && cd ..
     when:
       event: [push, tag, deployment]
 

--- a/.drone.yml
+++ b/.drone.yml
@@ -48,6 +48,7 @@ pipeline:
     image: plugins/git
     commands:
       - git clone https://github.com/UKHomeOffice/kube-pttg-ip-api.git
+      - git checkout EE-12142-proxy-timeout
     when:
       event: [push, tag, deployment]
 

--- a/.drone.yml
+++ b/.drone.yml
@@ -48,7 +48,6 @@ pipeline:
     image: plugins/git
     commands:
       - git clone https://github.com/UKHomeOffice/kube-pttg-ip-api.git
-      - cd kube-pttg-ip-api && git checkout -b EE-12142-timeout-proxy && cd ..
     when:
       event: [push, tag, deployment]
 

--- a/src/main/java/uk/gov/digital/ho/proving/income/application/ServiceConfiguration.java
+++ b/src/main/java/uk/gov/digital/ho/proving/income/application/ServiceConfiguration.java
@@ -84,7 +84,7 @@ public class ServiceConfiguration extends WebMvcConfigurerAdapter {
     }
 
     @Bean
-    RestTemplate createHmrcRestTemplate(RestTemplateBuilder restTemplateBuilder) {
+    RestTemplate hmrcRestTemplate(RestTemplateBuilder restTemplateBuilder) {
         return restTemplateBuilder
             .setReadTimeout(timeoutProperties.getHmrcService().getReadMs())
             .setConnectTimeout(timeoutProperties.getHmrcService().getConnectMs())
@@ -92,7 +92,7 @@ public class ServiceConfiguration extends WebMvcConfigurerAdapter {
     }
 
     @Bean
-    RestTemplate createAuditRestTemplate(RestTemplateBuilder restTemplateBuilder) {
+    RestTemplate auditRestTemplate(RestTemplateBuilder restTemplateBuilder) {
         return restTemplateBuilder
             .setReadTimeout(timeoutProperties.getAuditService().getReadMs())
             .setConnectTimeout(timeoutProperties.getAuditService().getConnectMs())

--- a/src/main/java/uk/gov/digital/ho/proving/income/application/ServiceConfiguration.java
+++ b/src/main/java/uk/gov/digital/ho/proving/income/application/ServiceConfiguration.java
@@ -29,13 +29,11 @@ import java.time.format.DateTimeFormatter;
 public class ServiceConfiguration extends WebMvcConfigurerAdapter {
 
     private final String apiDocsDir;
-    private final int restTemplateReadTimeoutInMillis;
-    private final int restTemplateConnectTimeoutInMillis;
+    private final TimeoutProperties timeoutProperties;
 
     public ServiceConfiguration(@Value("${apidocs.dir}") String apiDocsDir, TimeoutProperties timeoutProperties) {
         this.apiDocsDir = apiDocsDir;
-        this.restTemplateReadTimeoutInMillis = timeoutProperties.getHmrcService().getReadMs();
-        this.restTemplateConnectTimeoutInMillis = timeoutProperties.getHmrcService().getConnectMs();
+        this.timeoutProperties = timeoutProperties;
     }
 
     @Bean
@@ -81,23 +79,31 @@ public class ServiceConfiguration extends WebMvcConfigurerAdapter {
     }
 
     @Bean
-    public RequestData createRequestData() {
+    RequestData createRequestData() {
         return new RequestData();
     }
 
+//    @Bean
+//    public RestTemplate createRestTemplate(RestTemplateBuilder restTemplateBuilder) {
+//        return restTemplateBuilder
+//            .setReadTimeout()
+//            .setConnectTimeout(timeoutProperties.getHmrcService().getConnectMs())
+//            .build();
+//    }
+
     @Bean
-    public RestTemplate createRestTemplate(RestTemplateBuilder restTemplateBuilder) {
+    RestTemplate createHmrcRestTemplate(RestTemplateBuilder restTemplateBuilder) {
         return restTemplateBuilder
-            .setReadTimeout(restTemplateReadTimeoutInMillis)
-            .setConnectTimeout(restTemplateConnectTimeoutInMillis)
+            .setReadTimeout(timeoutProperties.getHmrcService().getReadMs())
+            .setConnectTimeout(timeoutProperties.getHmrcService().getConnectMs())
             .build();
     }
 
     @Bean
-    public RestTemplate createHmrcRestTemplate(RestTemplateBuilder restTemplateBuilder) {
+    public RestTemplate createAuditRestTemplate(RestTemplateBuilder restTemplateBuilder) {
         return restTemplateBuilder
-            .setReadTimeout(restTemplateReadTimeoutInMillis)
-            .setConnectTimeout(restTemplateConnectTimeoutInMillis)
+            .setReadTimeout(timeoutProperties.getAuditService().getReadMs())
+            .setConnectTimeout(timeoutProperties.getAuditService().getConnectMs())
             .build();
     }
 

--- a/src/main/java/uk/gov/digital/ho/proving/income/application/ServiceConfiguration.java
+++ b/src/main/java/uk/gov/digital/ho/proving/income/application/ServiceConfiguration.java
@@ -32,12 +32,10 @@ public class ServiceConfiguration extends WebMvcConfigurerAdapter {
     private final int restTemplateReadTimeoutInMillis;
     private final int restTemplateConnectTimeoutInMillis;
 
-    public ServiceConfiguration(@Value("${apidocs.dir}") String apiDocsDir,
-                                @Value("${resttemplate.timeout.read:30000}") int restTemplateReadTimeoutInMillis,
-                                @Value("${resttemplate.timeout.connect:30000}") int restTemplateConnectTimeoutInMillis) {
+    public ServiceConfiguration(@Value("${apidocs.dir}") String apiDocsDir, TimeoutProperties timeoutProperties) {
         this.apiDocsDir = apiDocsDir;
-        this.restTemplateReadTimeoutInMillis = restTemplateReadTimeoutInMillis;
-        this.restTemplateConnectTimeoutInMillis = restTemplateConnectTimeoutInMillis;
+        this.restTemplateReadTimeoutInMillis = timeoutProperties.getHmrcService().getReadMs();
+        this.restTemplateConnectTimeoutInMillis = timeoutProperties.getHmrcService().getConnectMs();
     }
 
     @Bean
@@ -89,6 +87,14 @@ public class ServiceConfiguration extends WebMvcConfigurerAdapter {
 
     @Bean
     public RestTemplate createRestTemplate(RestTemplateBuilder restTemplateBuilder) {
+        return restTemplateBuilder
+            .setReadTimeout(restTemplateReadTimeoutInMillis)
+            .setConnectTimeout(restTemplateConnectTimeoutInMillis)
+            .build();
+    }
+
+    @Bean
+    public RestTemplate createHmrcRestTemplate(RestTemplateBuilder restTemplateBuilder) {
         return restTemplateBuilder
             .setReadTimeout(restTemplateReadTimeoutInMillis)
             .setConnectTimeout(restTemplateConnectTimeoutInMillis)

--- a/src/main/java/uk/gov/digital/ho/proving/income/application/ServiceConfiguration.java
+++ b/src/main/java/uk/gov/digital/ho/proving/income/application/ServiceConfiguration.java
@@ -83,14 +83,6 @@ public class ServiceConfiguration extends WebMvcConfigurerAdapter {
         return new RequestData();
     }
 
-//    @Bean
-//    public RestTemplate createRestTemplate(RestTemplateBuilder restTemplateBuilder) {
-//        return restTemplateBuilder
-//            .setReadTimeout()
-//            .setConnectTimeout(timeoutProperties.getHmrcService().getConnectMs())
-//            .build();
-//    }
-
     @Bean
     RestTemplate createHmrcRestTemplate(RestTemplateBuilder restTemplateBuilder) {
         return restTemplateBuilder
@@ -100,7 +92,7 @@ public class ServiceConfiguration extends WebMvcConfigurerAdapter {
     }
 
     @Bean
-    public RestTemplate createAuditRestTemplate(RestTemplateBuilder restTemplateBuilder) {
+    RestTemplate createAuditRestTemplate(RestTemplateBuilder restTemplateBuilder) {
         return restTemplateBuilder
             .setReadTimeout(timeoutProperties.getAuditService().getReadMs())
             .setConnectTimeout(timeoutProperties.getAuditService().getConnectMs())

--- a/src/main/java/uk/gov/digital/ho/proving/income/application/TimeoutProperties.java
+++ b/src/main/java/uk/gov/digital/ho/proving/income/application/TimeoutProperties.java
@@ -14,7 +14,7 @@ public class TimeoutProperties {
 
     private HmrcService hmrcService;
 
-    static class HmrcService extends TimeoutPropertiesTemplate {}
+    public static class HmrcService extends TimeoutPropertiesTemplate {}
 
     @NoArgsConstructor
     @Setter

--- a/src/main/java/uk/gov/digital/ho/proving/income/application/TimeoutProperties.java
+++ b/src/main/java/uk/gov/digital/ho/proving/income/application/TimeoutProperties.java
@@ -13,8 +13,10 @@ import org.springframework.context.annotation.Configuration;
 public class TimeoutProperties {
 
     private HmrcService hmrcService;
+    private AuditService auditService;
 
     public static class HmrcService extends TimeoutPropertiesTemplate {}
+    public static class AuditService extends TimeoutPropertiesTemplate {}
 
     @NoArgsConstructor
     @Setter

--- a/src/main/java/uk/gov/digital/ho/proving/income/application/TimeoutProperties.java
+++ b/src/main/java/uk/gov/digital/ho/proving/income/application/TimeoutProperties.java
@@ -1,0 +1,26 @@
+package uk.gov.digital.ho.proving.income.application;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+@ConfigurationProperties(prefix = "timeouts")
+@Getter
+@Setter
+public class TimeoutProperties {
+
+    private HmrcService hmrcService;
+
+    static class HmrcService extends TimeoutPropertiesTemplate {}
+
+    @NoArgsConstructor
+    @Setter
+    @Getter
+    private static class TimeoutPropertiesTemplate {
+        private int readMs;
+        private int connectMs;
+    }
+}

--- a/src/main/java/uk/gov/digital/ho/proving/income/audit/AuditClient.java
+++ b/src/main/java/uk/gov/digital/ho/proving/income/audit/AuditClient.java
@@ -74,9 +74,9 @@ public class AuditClient {
     }
 
     @Retryable(
-        value = {RestClientException.class},
-        maxAttemptsExpression = "#{${audit.service.retry.attempts}}",
-        backoff = @Backoff(delayExpression = "#{${audit.service.retry.delay}}"))
+            value = { RestClientException.class },
+            maxAttemptsExpression = "#{${audit.service.retry.attempts}}",
+            backoff = @Backoff(delayExpression = "#{${audit.service.retry.delay}}"))
     private void dispatchAuditableData(AuditableData auditableData) {
         restTemplate.exchange(auditEndpoint, POST, toEntity(auditableData), Void.class);
     }
@@ -90,15 +90,13 @@ public class AuditClient {
             .toUri();
 
         HttpEntity<Void> entity = new HttpEntity<>(generateRestHeaders());
-        ResponseEntity<List<AuditRecord>> auditRecords = restTemplate.exchange(uri, GET, entity, new ParameterizedTypeReference<List<AuditRecord>>() {
-        });
+        ResponseEntity<List<AuditRecord>> auditRecords = restTemplate.exchange(uri, GET, entity, new ParameterizedTypeReference<List<AuditRecord>>() {});
         return auditRecords.getBody();
     }
 
     void archiveAudit(ArchiveAuditRequest request) {
         HttpEntity<ArchiveAuditRequest> entity = new HttpEntity<>(request, generateRestHeaders());
-        ResponseEntity<ArchiveAuditResponse> response = restTemplate.exchange(auditArchiveEndpoint, POST, entity, new ParameterizedTypeReference<ArchiveAuditResponse>() {
-        });
+        ResponseEntity<ArchiveAuditResponse> response = restTemplate.exchange(auditArchiveEndpoint, POST, entity, new ParameterizedTypeReference<ArchiveAuditResponse>() {});
     }
 
     @Recover
@@ -108,14 +106,14 @@ public class AuditClient {
 
     private AuditableData generateAuditableData(AuditEventType eventType, UUID eventId, Map<String, Object> auditDetail) throws JsonProcessingException {
         return new AuditableData(eventId.toString(),
-            LocalDateTime.now(clock),
-            requestData.sessionId(),
-            requestData.correlationId(),
-            requestData.userId(),
-            requestData.deploymentName(),
-            requestData.deploymentNamespace(),
-            eventType,
-            mapper.writeValueAsString(auditDetail));
+                                    LocalDateTime.now(clock),
+                                    requestData.sessionId(),
+                                    requestData.correlationId(),
+                                    requestData.userId(),
+                                    requestData.deploymentName(),
+                                    requestData.deploymentNamespace(),
+                                    eventType,
+                                    mapper.writeValueAsString(auditDetail));
     }
 
     private HttpEntity<AuditableData> toEntity(AuditableData auditableData) {

--- a/src/main/java/uk/gov/digital/ho/proving/income/audit/AuditClient.java
+++ b/src/main/java/uk/gov/digital/ho/proving/income/audit/AuditClient.java
@@ -45,7 +45,7 @@ public class AuditClient {
     private final ObjectMapper mapper;
 
     public AuditClient(Clock clock,
-                       @Qualifier("createAuditRestTemplate")RestTemplate restTemplate,
+                       @Qualifier("auditRestTemplate") RestTemplate restTemplate,
                        RequestData requestData,
                        @Value("${pttg.audit.endpoint}") String auditEndpoint,
                        @Value("${audit.history.endpoint}") String auditHistoryEndpoint,
@@ -74,9 +74,9 @@ public class AuditClient {
     }
 
     @Retryable(
-            value = { RestClientException.class },
-            maxAttemptsExpression = "#{${audit.service.retry.attempts}}",
-            backoff = @Backoff(delayExpression = "#{${audit.service.retry.delay}}"))
+        value = {RestClientException.class},
+        maxAttemptsExpression = "#{${audit.service.retry.attempts}}",
+        backoff = @Backoff(delayExpression = "#{${audit.service.retry.delay}}"))
     private void dispatchAuditableData(AuditableData auditableData) {
         restTemplate.exchange(auditEndpoint, POST, toEntity(auditableData), Void.class);
     }
@@ -90,13 +90,15 @@ public class AuditClient {
             .toUri();
 
         HttpEntity<Void> entity = new HttpEntity<>(generateRestHeaders());
-        ResponseEntity<List<AuditRecord>> auditRecords = restTemplate.exchange(uri, GET, entity, new ParameterizedTypeReference<List<AuditRecord>>() {});
+        ResponseEntity<List<AuditRecord>> auditRecords = restTemplate.exchange(uri, GET, entity, new ParameterizedTypeReference<List<AuditRecord>>() {
+        });
         return auditRecords.getBody();
     }
 
     void archiveAudit(ArchiveAuditRequest request) {
         HttpEntity<ArchiveAuditRequest> entity = new HttpEntity<>(request, generateRestHeaders());
-        ResponseEntity<ArchiveAuditResponse> response = restTemplate.exchange(auditArchiveEndpoint, POST, entity, new ParameterizedTypeReference<ArchiveAuditResponse>() {});
+        ResponseEntity<ArchiveAuditResponse> response = restTemplate.exchange(auditArchiveEndpoint, POST, entity, new ParameterizedTypeReference<ArchiveAuditResponse>() {
+        });
     }
 
     @Recover
@@ -106,14 +108,14 @@ public class AuditClient {
 
     private AuditableData generateAuditableData(AuditEventType eventType, UUID eventId, Map<String, Object> auditDetail) throws JsonProcessingException {
         return new AuditableData(eventId.toString(),
-                                    LocalDateTime.now(clock),
-                                    requestData.sessionId(),
-                                    requestData.correlationId(),
-                                    requestData.userId(),
-                                    requestData.deploymentName(),
-                                    requestData.deploymentNamespace(),
-                                    eventType,
-                                    mapper.writeValueAsString(auditDetail));
+            LocalDateTime.now(clock),
+            requestData.sessionId(),
+            requestData.correlationId(),
+            requestData.userId(),
+            requestData.deploymentName(),
+            requestData.deploymentNamespace(),
+            eventType,
+            mapper.writeValueAsString(auditDetail));
     }
 
     private HttpEntity<AuditableData> toEntity(AuditableData auditableData) {

--- a/src/main/java/uk/gov/digital/ho/proving/income/audit/AuditClient.java
+++ b/src/main/java/uk/gov/digital/ho/proving/income/audit/AuditClient.java
@@ -3,6 +3,7 @@ package uk.gov.digital.ho.proving.income.audit;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.core.ParameterizedTypeReference;
 import org.springframework.http.HttpEntity;
@@ -17,13 +18,11 @@ import org.springframework.web.client.RestTemplate;
 import org.springframework.web.util.UriComponentsBuilder;
 import uk.gov.digital.ho.proving.income.api.RequestData;
 
-import javax.swing.text.DateFormatter;
 import java.net.URI;
 import java.time.Clock;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.format.DateTimeFormatter;
-import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.UUID;
@@ -46,7 +45,7 @@ public class AuditClient {
     private final ObjectMapper mapper;
 
     public AuditClient(Clock clock,
-                       RestTemplate restTemplate,
+                       @Qualifier("createAuditRestTemplate")RestTemplate restTemplate,
                        RequestData requestData,
                        @Value("${pttg.audit.endpoint}") String auditEndpoint,
                        @Value("${audit.history.endpoint}") String auditHistoryEndpoint,

--- a/src/main/java/uk/gov/digital/ho/proving/income/hmrc/HmrcClient.java
+++ b/src/main/java/uk/gov/digital/ho/proving/income/hmrc/HmrcClient.java
@@ -1,6 +1,7 @@
 package uk.gov.digital.ho.proving.income.hmrc;
 
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.HttpEntity;
 import org.springframework.http.HttpHeaders;
@@ -35,10 +36,10 @@ public class HmrcClient {
     private final RequestData requestData;
     private final ServiceResponseLogger serviceResponseLogger;
 
-    public HmrcClient(RestTemplate restTemplate,
-                      @Value("${hmrc.service.endpoint}") String hmrcServiceEndpoint,
-                      RequestData requestData,
-                      ServiceResponseLogger serviceResponseLogger) {
+    HmrcClient(@Qualifier("createHmrcRestTemplate") RestTemplate restTemplate,
+               @Value("${hmrc.service.endpoint}") String hmrcServiceEndpoint,
+               RequestData requestData,
+               ServiceResponseLogger serviceResponseLogger) {
         this.restTemplate = restTemplate;
         this.hmrcServiceEndpoint = hmrcServiceEndpoint;
         this.requestData = requestData;

--- a/src/main/java/uk/gov/digital/ho/proving/income/hmrc/HmrcClient.java
+++ b/src/main/java/uk/gov/digital/ho/proving/income/hmrc/HmrcClient.java
@@ -36,7 +36,7 @@ public class HmrcClient {
     private final RequestData requestData;
     private final ServiceResponseLogger serviceResponseLogger;
 
-    HmrcClient(@Qualifier("createHmrcRestTemplate") RestTemplate restTemplate,
+    HmrcClient(@Qualifier("hmrcRestTemplate") RestTemplate restTemplate,
                @Value("${hmrc.service.endpoint}") String hmrcServiceEndpoint,
                RequestData requestData,
                ServiceResponseLogger serviceResponseLogger) {

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -70,3 +70,8 @@ audit.history.months=6
 audit.history.endpoint=${pttg.audit.url}/history
 audit.archive.endpoint=${pttg.audit.url}/archive
 
+#
+# Service timeouts
+#
+timeouts.hmrc-service.read-ms=120000
+timeouts.hmrc-service.connect-ms=1000

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -73,7 +73,7 @@ audit.archive.endpoint=${pttg.audit.url}/archive
 #
 # Service timeouts
 #
-timeouts.hmrc-service.read-ms=120000
+timeouts.hmrc-service.read-ms=110000
 timeouts.hmrc-service.connect-ms=1000
 timeouts.audit-service.read-ms=10000
 timeouts.audit-service.connect-ms=1000

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -75,3 +75,5 @@ audit.archive.endpoint=${pttg.audit.url}/archive
 #
 timeouts.hmrc-service.read-ms=120000
 timeouts.hmrc-service.connect-ms=1000
+timeouts.audit-service.read-ms=10000
+timeouts.audit-service.connect-ms=1000

--- a/src/test/java/uk/gov/digital/ho/proving/income/api/domain/ApplicantSerializeTest.java
+++ b/src/test/java/uk/gov/digital/ho/proving/income/api/domain/ApplicantSerializeTest.java
@@ -3,6 +3,7 @@ package uk.gov.digital.ho.proving.income.api.domain;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.junit.Test;
 import uk.gov.digital.ho.proving.income.application.ServiceConfiguration;
+import uk.gov.digital.ho.proving.income.application.TimeoutProperties;
 
 import java.io.IOException;
 import java.time.LocalDate;
@@ -12,7 +13,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 public class ApplicantSerializeTest {
 
-    private ObjectMapper objectMapper = new ServiceConfiguration("", 0, 0).createObjectMapper();
+    private ObjectMapper objectMapper = new ServiceConfiguration("", new TimeoutProperties()).createObjectMapper();
 
     @Test
     public void thatJsonIsDeserialized() throws IOException {

--- a/src/test/java/uk/gov/digital/ho/proving/income/api/domain/BaseResponseSerializeTest.java
+++ b/src/test/java/uk/gov/digital/ho/proving/income/api/domain/BaseResponseSerializeTest.java
@@ -7,6 +7,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
 import uk.gov.digital.ho.proving.income.application.ServiceConfiguration;
+import uk.gov.digital.ho.proving.income.application.TimeoutProperties;
 
 import java.io.IOException;
 
@@ -14,7 +15,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 public class BaseResponseSerializeTest {
 
-    private ObjectMapper objectMapper = new ServiceConfiguration("", 0, 0).createObjectMapper();
+    private ObjectMapper objectMapper = new ServiceConfiguration("", new TimeoutProperties()).createObjectMapper();
 
     @Test
     public void thatJsonIsDeserialized() throws IOException {

--- a/src/test/java/uk/gov/digital/ho/proving/income/api/domain/CategoryCheckSerializeTest.java
+++ b/src/test/java/uk/gov/digital/ho/proving/income/api/domain/CategoryCheckSerializeTest.java
@@ -3,6 +3,7 @@ package uk.gov.digital.ho.proving.income.api.domain;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.junit.Test;
 import uk.gov.digital.ho.proving.income.application.ServiceConfiguration;
+import uk.gov.digital.ho.proving.income.application.TimeoutProperties;
 import uk.gov.digital.ho.proving.income.validator.domain.IncomeValidationStatus;
 
 import java.io.IOException;
@@ -15,7 +16,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 public class CategoryCheckSerializeTest {
 
-    private ObjectMapper objectMapper = new ServiceConfiguration("", 0, 0).createObjectMapper();
+    private ObjectMapper objectMapper = new ServiceConfiguration("", new TimeoutProperties()).createObjectMapper();
 
     @Test
     public void thatJsonIsDeserialized() throws IOException {

--- a/src/test/java/uk/gov/digital/ho/proving/income/api/domain/CheckedIndividualSerializeTest.java
+++ b/src/test/java/uk/gov/digital/ho/proving/income/api/domain/CheckedIndividualSerializeTest.java
@@ -3,6 +3,7 @@ package uk.gov.digital.ho.proving.income.api.domain;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.junit.Test;
 import uk.gov.digital.ho.proving.income.application.ServiceConfiguration;
+import uk.gov.digital.ho.proving.income.application.TimeoutProperties;
 
 import java.io.IOException;
 import java.util.Arrays;
@@ -11,7 +12,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 public class CheckedIndividualSerializeTest {
 
-    private ObjectMapper objectMapper = new ServiceConfiguration("", 0, 0).createObjectMapper();
+    private ObjectMapper objectMapper = new ServiceConfiguration("", new TimeoutProperties()).createObjectMapper();
 
     @Test
     public void thatJsonIsDeserialized() throws IOException {

--- a/src/test/java/uk/gov/digital/ho/proving/income/api/domain/FinancialCheckResponseSerializeTest.java
+++ b/src/test/java/uk/gov/digital/ho/proving/income/api/domain/FinancialCheckResponseSerializeTest.java
@@ -3,6 +3,7 @@ package uk.gov.digital.ho.proving.income.api.domain;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.junit.Test;
 import uk.gov.digital.ho.proving.income.application.ServiceConfiguration;
+import uk.gov.digital.ho.proving.income.application.TimeoutProperties;
 
 import java.io.IOException;
 import java.util.ArrayList;
@@ -11,7 +12,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 public class FinancialCheckResponseSerializeTest {
 
-    private ObjectMapper objectMapper = new ServiceConfiguration("", 0, 0).createObjectMapper();
+    private ObjectMapper objectMapper = new ServiceConfiguration("", new TimeoutProperties()).createObjectMapper();
 
     @Test
     public void thatJsonIsDeserialized() throws IOException {

--- a/src/test/java/uk/gov/digital/ho/proving/income/api/domain/FinancialStatusRequestDeserializeTest.java
+++ b/src/test/java/uk/gov/digital/ho/proving/income/api/domain/FinancialStatusRequestDeserializeTest.java
@@ -3,6 +3,7 @@ package uk.gov.digital.ho.proving.income.api.domain;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.junit.Test;
 import uk.gov.digital.ho.proving.income.application.ServiceConfiguration;
+import uk.gov.digital.ho.proving.income.application.TimeoutProperties;
 
 import java.io.IOException;
 import java.time.LocalDate;
@@ -13,7 +14,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 public class FinancialStatusRequestDeserializeTest {
 
-    private ObjectMapper objectMapper = new ServiceConfiguration("", 0, 0).createObjectMapper();
+    private ObjectMapper objectMapper = new ServiceConfiguration("", new TimeoutProperties()).createObjectMapper();
 
     @Test
     public void thatJsonIsDeserialized() throws IOException {

--- a/src/test/java/uk/gov/digital/ho/proving/income/application/ServiceConfigurationTest.java
+++ b/src/test/java/uk/gov/digital/ho/proving/income/application/ServiceConfigurationTest.java
@@ -22,23 +22,28 @@ public class ServiceConfigurationTest {
     @Mock
     private RestTemplate mockRestTemplate;
 
+    private TimeoutProperties timeoutProperties = new TimeoutProperties();
+
     @Before
     public void setUp() {
         when(mockRestTemplateBuilder.setReadTimeout(anyInt())).thenReturn(mockRestTemplateBuilder);
         when(mockRestTemplateBuilder.setConnectTimeout(anyInt())).thenReturn(mockRestTemplateBuilder);
-
         when(mockRestTemplateBuilder.build()).thenReturn(mockRestTemplate);
+
+        timeoutProperties.setHmrcService(new TimeoutProperties.HmrcService());
     }
 
     @Test
-    public void shouldSetTimeoutsOnRestTemplate() {
+    public void shouldSetTimeoutsOnHmrcRestTemplate() {
         // given
         int readTimeout = 1234;
         int connectTimeout = 4321;
-        ServiceConfiguration springConfig = new ServiceConfiguration(null, readTimeout, connectTimeout);
+        timeoutProperties.getHmrcService().setReadMs(readTimeout);
+        timeoutProperties.getHmrcService().setConnectMs(connectTimeout);
+        ServiceConfiguration springConfig = new ServiceConfiguration(null, timeoutProperties);
 
         // when
-        RestTemplate restTemplate = springConfig.createRestTemplate(mockRestTemplateBuilder);
+        RestTemplate restTemplate = springConfig.createHmrcRestTemplate(mockRestTemplateBuilder);
 
         // then
         verify(mockRestTemplateBuilder).setReadTimeout(readTimeout);

--- a/src/test/java/uk/gov/digital/ho/proving/income/application/ServiceConfigurationTest.java
+++ b/src/test/java/uk/gov/digital/ho/proving/income/application/ServiceConfigurationTest.java
@@ -41,10 +41,8 @@ public class ServiceConfigurationTest {
         timeoutProperties.getHmrcService().setReadMs(readTimeout);
         timeoutProperties.getHmrcService().setConnectMs(connectTimeout);
         ServiceConfiguration springConfig = new ServiceConfiguration(null, timeoutProperties);
-
         // when
         RestTemplate restTemplate = springConfig.createHmrcRestTemplate(mockRestTemplateBuilder);
-
         // then
         verify(mockRestTemplateBuilder).setReadTimeout(readTimeout);
         verify(mockRestTemplateBuilder).setConnectTimeout(connectTimeout);

--- a/src/test/java/uk/gov/digital/ho/proving/income/application/ServiceConfigurationTest.java
+++ b/src/test/java/uk/gov/digital/ho/proving/income/application/ServiceConfigurationTest.java
@@ -43,7 +43,7 @@ public class ServiceConfigurationTest {
         timeoutProperties.getHmrcService().setConnectMs(connectTimeout);
         ServiceConfiguration springConfig = new ServiceConfiguration(null, timeoutProperties);
         // when
-        RestTemplate restTemplate = springConfig.createHmrcRestTemplate(mockRestTemplateBuilder);
+        RestTemplate restTemplate = springConfig.hmrcRestTemplate(mockRestTemplateBuilder);
         // then
         verify(mockRestTemplateBuilder).setReadTimeout(readTimeout);
         verify(mockRestTemplateBuilder).setConnectTimeout(connectTimeout);
@@ -60,7 +60,7 @@ public class ServiceConfigurationTest {
         timeoutProperties.getAuditService().setConnectMs(connectTimeout);
         ServiceConfiguration springConfig = new ServiceConfiguration(null, timeoutProperties);
         // when
-        RestTemplate restTemplate = springConfig.createAuditRestTemplate(mockRestTemplateBuilder);
+        RestTemplate restTemplate = springConfig.auditRestTemplate(mockRestTemplateBuilder);
         // then
         verify(mockRestTemplateBuilder).setReadTimeout(readTimeout);
         verify(mockRestTemplateBuilder).setConnectTimeout(connectTimeout);

--- a/src/test/java/uk/gov/digital/ho/proving/income/application/ServiceConfigurationTest.java
+++ b/src/test/java/uk/gov/digital/ho/proving/income/application/ServiceConfigurationTest.java
@@ -31,6 +31,7 @@ public class ServiceConfigurationTest {
         when(mockRestTemplateBuilder.build()).thenReturn(mockRestTemplate);
 
         timeoutProperties.setHmrcService(new TimeoutProperties.HmrcService());
+        timeoutProperties.setAuditService(new TimeoutProperties.AuditService());
     }
 
     @Test
@@ -43,6 +44,23 @@ public class ServiceConfigurationTest {
         ServiceConfiguration springConfig = new ServiceConfiguration(null, timeoutProperties);
         // when
         RestTemplate restTemplate = springConfig.createHmrcRestTemplate(mockRestTemplateBuilder);
+        // then
+        verify(mockRestTemplateBuilder).setReadTimeout(readTimeout);
+        verify(mockRestTemplateBuilder).setConnectTimeout(connectTimeout);
+
+        assertThat(restTemplate).isEqualTo(mockRestTemplate);
+    }
+
+    @Test
+    public void shouldSetTimeoutsOnAuditRestTemplate() {
+        // given
+        int readTimeout = 2468;
+        int connectTimeout = 1357;
+        timeoutProperties.getAuditService().setReadMs(readTimeout);
+        timeoutProperties.getAuditService().setConnectMs(connectTimeout);
+        ServiceConfiguration springConfig = new ServiceConfiguration(null, timeoutProperties);
+        // when
+        RestTemplate restTemplate = springConfig.createAuditRestTemplate(mockRestTemplateBuilder);
         // then
         verify(mockRestTemplateBuilder).setReadTimeout(readTimeout);
         verify(mockRestTemplateBuilder).setConnectTimeout(connectTimeout);

--- a/src/test/java/uk/gov/digital/ho/proving/income/application/TimeoutPropertiesTest.java
+++ b/src/test/java/uk/gov/digital/ho/proving/income/application/TimeoutPropertiesTest.java
@@ -1,8 +1,8 @@
 package uk.gov.digital.ho.proving.income.application;
 
-import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.boot.test.context.TestConfiguration;
 import org.springframework.test.context.ContextConfiguration;
@@ -24,17 +24,13 @@ public class TimeoutPropertiesTest {
     @EnableConfigurationProperties
     public static class TestConfig {}
 
-    private TimeoutProperties timeoutProperties = new TimeoutProperties();
-
-    @Before
-    public void setup() {
-        timeoutProperties.setHmrcService(new TimeoutProperties.HmrcService());
-    }
+    @Autowired
+    private TimeoutProperties timeoutProperties;
 
     @Test
     public void shouldLoadRestTemplateTimeouts() {
-        assertThat(timeoutProperties.getHmrcService().getReadMs()).isEqualTo(1000);
-        assertThat(timeoutProperties.getHmrcService().getConnectMs()).isEqualTo(2000);
+        assertThat(timeoutProperties.getHmrcService().getReadMs()).isEqualTo(120000);
+        assertThat(timeoutProperties.getHmrcService().getConnectMs()).isEqualTo(1000);
     }
 }
 

--- a/src/test/java/uk/gov/digital/ho/proving/income/application/TimeoutPropertiesTest.java
+++ b/src/test/java/uk/gov/digital/ho/proving/income/application/TimeoutPropertiesTest.java
@@ -15,14 +15,16 @@ import static org.assertj.core.api.Assertions.assertThat;
 @ContextConfiguration(classes = {TimeoutProperties.class, TimeoutPropertiesTest.TestConfig.class})
 @TestPropertySource(properties = {
     "timeouts.hmrc-service.read-ms=120000",
-    "timeouts.hmrc-service.connect-ms=1000"
+    "timeouts.hmrc-service.connect-ms=1000",
+    "timeouts.audit-service.read-ms=10000",
+    "timeouts.audit-service.connect-ms=1000"
 })
 
 public class TimeoutPropertiesTest {
 
     @TestConfiguration
     @EnableConfigurationProperties
-    public static class TestConfig {}
+    static class TestConfig {}
 
     @Autowired
     private TimeoutProperties timeoutProperties;
@@ -31,6 +33,8 @@ public class TimeoutPropertiesTest {
     public void shouldLoadRestTemplateTimeouts() {
         assertThat(timeoutProperties.getHmrcService().getReadMs()).isEqualTo(120000);
         assertThat(timeoutProperties.getHmrcService().getConnectMs()).isEqualTo(1000);
+        assertThat(timeoutProperties.getAuditService().getReadMs()).isEqualTo(10000);
+        assertThat(timeoutProperties.getAuditService().getConnectMs()).isEqualTo(1000);
     }
 }
 

--- a/src/test/java/uk/gov/digital/ho/proving/income/application/TimeoutPropertiesTest.java
+++ b/src/test/java/uk/gov/digital/ho/proving/income/application/TimeoutPropertiesTest.java
@@ -1,0 +1,40 @@
+package uk.gov.digital.ho.proving.income.application;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.TestPropertySource;
+import org.springframework.test.context.junit4.SpringRunner;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@RunWith(SpringRunner.class)
+@ContextConfiguration(classes = {TimeoutProperties.class, TimeoutPropertiesTest.TestConfig.class})
+@TestPropertySource(properties = {
+    "timeouts.hmrc-service.read-ms=120000",
+    "timeouts.hmrc-service.connect-ms=1000"
+})
+
+public class TimeoutPropertiesTest {
+
+    @TestConfiguration
+    @EnableConfigurationProperties
+    public static class TestConfig {}
+
+    private TimeoutProperties timeoutProperties = new TimeoutProperties();
+
+    @Before
+    public void setup() {
+        timeoutProperties.setHmrcService(new TimeoutProperties.HmrcService());
+    }
+
+    @Test
+    public void shouldLoadRestTemplateTimeouts() {
+        assertThat(timeoutProperties.getHmrcService().getReadMs()).isEqualTo(1000);
+        assertThat(timeoutProperties.getHmrcService().getConnectMs()).isEqualTo(2000);
+    }
+}
+

--- a/src/test/java/uk/gov/digital/ho/proving/income/audit/AuditArchiveServiceIT.java
+++ b/src/test/java/uk/gov/digital/ho/proving/income/audit/AuditArchiveServiceIT.java
@@ -31,7 +31,7 @@ properties = {
 public class AuditArchiveServiceIT {
 
     @Autowired
-    @Qualifier("createAuditRestTemplate")
+    @Qualifier("auditRestTemplate")
     private RestTemplate restTemplate;
     @Autowired
     private AuditArchiveService auditArchiveService;

--- a/src/test/java/uk/gov/digital/ho/proving/income/audit/AuditArchiveServiceIT.java
+++ b/src/test/java/uk/gov/digital/ho/proving/income/audit/AuditArchiveServiceIT.java
@@ -4,6 +4,7 @@ import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.context.junit4.SpringRunner;
 import org.springframework.test.web.client.MockRestServiceServer;
@@ -30,6 +31,7 @@ properties = {
 public class AuditArchiveServiceIT {
 
     @Autowired
+    @Qualifier("createAuditRestTemplate")
     private RestTemplate restTemplate;
     @Autowired
     private AuditArchiveService auditArchiveService;

--- a/src/test/java/uk/gov/digital/ho/proving/income/audit/AuditRecordTest.java
+++ b/src/test/java/uk/gov/digital/ho/proving/income/audit/AuditRecordTest.java
@@ -8,6 +8,7 @@ import org.springframework.beans.factory.annotation.Value;
 import org.springframework.core.io.Resource;
 import org.springframework.test.context.junit4.SpringRunner;
 import uk.gov.digital.ho.proving.income.application.ServiceConfiguration;
+import uk.gov.digital.ho.proving.income.application.TimeoutProperties;
 
 import java.io.IOException;
 import java.nio.file.Files;
@@ -19,7 +20,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 @RunWith(SpringRunner.class)
 public class AuditRecordTest {
 
-    private ObjectMapper objectMapper = new ServiceConfiguration("", 0, 0).createObjectMapper();
+    private ObjectMapper objectMapper = new ServiceConfiguration("", new TimeoutProperties()).createObjectMapper();
 
     @Value("classpath:json/AuditRecordRequest.json")
     private Resource auditRecordRequest;

--- a/src/test/java/uk/gov/digital/ho/proving/income/hmrc/domain/AnnualSelfAssessmentTaxReturnTest.java
+++ b/src/test/java/uk/gov/digital/ho/proving/income/hmrc/domain/AnnualSelfAssessmentTaxReturnTest.java
@@ -3,6 +3,7 @@ package uk.gov.digital.ho.proving.income.hmrc.domain;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.junit.Test;
 import uk.gov.digital.ho.proving.income.application.ServiceConfiguration;
+import uk.gov.digital.ho.proving.income.application.TimeoutProperties;
 
 import java.io.IOException;
 import java.math.BigDecimal;
@@ -11,7 +12,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 public class AnnualSelfAssessmentTaxReturnTest {
 
-    private ObjectMapper objectMapper = new ServiceConfiguration("", 0, 0).createObjectMapper();
+    private ObjectMapper objectMapper = new ServiceConfiguration("", new TimeoutProperties()).createObjectMapper();
 
     @Test
     public void shouldDeserialize() throws IOException {

--- a/src/test/java/uk/gov/digital/ho/proving/income/hmrc/domain/HmrcIndividualTest.java
+++ b/src/test/java/uk/gov/digital/ho/proving/income/hmrc/domain/HmrcIndividualTest.java
@@ -3,6 +3,7 @@ package uk.gov.digital.ho.proving.income.hmrc.domain;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.junit.Test;
 import uk.gov.digital.ho.proving.income.application.ServiceConfiguration;
+import uk.gov.digital.ho.proving.income.application.TimeoutProperties;
 
 import java.io.IOException;
 import java.time.LocalDate;
@@ -10,7 +11,7 @@ import java.time.LocalDate;
 import static org.assertj.core.api.Java6Assertions.assertThat;
 
 public class HmrcIndividualTest {
-    private ObjectMapper objectMapper = new ServiceConfiguration("", 0, 0).createObjectMapper();
+    private ObjectMapper objectMapper = new ServiceConfiguration("", new TimeoutProperties()).createObjectMapper();
 
     @Test
     public void thatJsonIsDeserialized() throws IOException {

--- a/src/test/java/uk/gov/digital/ho/proving/income/hmrc/domain/IncomeRecordTest.java
+++ b/src/test/java/uk/gov/digital/ho/proving/income/hmrc/domain/IncomeRecordTest.java
@@ -3,6 +3,7 @@ package uk.gov.digital.ho.proving.income.hmrc.domain;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.junit.Test;
 import uk.gov.digital.ho.proving.income.application.ServiceConfiguration;
+import uk.gov.digital.ho.proving.income.application.TimeoutProperties;
 
 import java.io.IOException;
 import java.math.BigDecimal;
@@ -63,7 +64,7 @@ public class IncomeRecordTest {
 
     @Test
     public void shouldDeserializeJson() throws IOException {
-        ObjectMapper objectMapper = new ServiceConfiguration("", 0, 0).createObjectMapper();
+        ObjectMapper objectMapper = new ServiceConfiguration("", new TimeoutProperties()).createObjectMapper();
 
         String json = "{\"paye\":[],\"selfAssessment\":[],\"employments\":[],\"individual\":{\"firstName\": \"firstname\", \"lastName\": \"lastname\", \"dateOfBirth\": \"1970-01-01\", \"nino\": \"QQ123456C\"}}";
 


### PR DESCRIPTION
Instead of relying on default timeouts for service-service calls it was decided to follow a pattern already done in RPS and make the timeouts configurable.
This adds separate methods for creating rest templates for HMRC service and Audit service and updates the existing tests to use the new pattern.