### PR TITLE
Ee 16843 Pass Rate Statistics Service

### DIFF
--- a/src/main/java/uk/gov/digital/ho/proving/income/audit/AuditClient.java
+++ b/src/main/java/uk/gov/digital/ho/proving/income/audit/AuditClient.java
@@ -17,13 +17,11 @@ import org.springframework.web.client.RestTemplate;
 import org.springframework.web.util.UriComponentsBuilder;
 import uk.gov.digital.ho.proving.income.api.RequestData;
 
-import javax.swing.text.DateFormatter;
 import java.net.URI;
 import java.time.Clock;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.format.DateTimeFormatter;
-import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.UUID;
@@ -93,6 +91,20 @@ public class AuditClient {
         HttpEntity<Void> entity = new HttpEntity<>(generateRestHeaders());
         ResponseEntity<List<AuditRecord>> auditRecords = restTemplate.exchange(uri, GET, entity, new ParameterizedTypeReference<List<AuditRecord>>() {});
         return auditRecords.getBody();
+    }
+
+    List<AuditRecord> getAuditHistoryPaginated(List<AuditEventType> eventTypes, int page, int size) {
+        URI uri = UriComponentsBuilder.fromHttpUrl(auditHistoryEndpoint)
+            .queryParam("eventTypes", eventTypes)
+            .queryParam("page", page)
+            .queryParam("size", size)
+            .build()
+            .encode()
+            .toUri();
+
+        HttpEntity<Void> entity = new HttpEntity<>(generateRestHeaders());
+        ResponseEntity<List<AuditRecord>> response = restTemplate.exchange(uri, GET, entity, new ParameterizedTypeReference<List<AuditRecord>>() {});
+        return response.getBody();
     }
 
     void archiveAudit(ArchiveAuditRequest request) {

--- a/src/main/java/uk/gov/digital/ho/proving/income/audit/AuditClient.java
+++ b/src/main/java/uk/gov/digital/ho/proving/income/audit/AuditClient.java
@@ -93,7 +93,7 @@ public class AuditClient {
         return auditRecords.getBody();
     }
 
-    List<AuditRecord> getAuditHistoryPaginated(List<AuditEventType> eventTypes, int page, int size) {
+    public List<AuditRecord> getAuditHistoryPaginated(List<AuditEventType> eventTypes, int page, int size) {
         URI uri = UriComponentsBuilder.fromHttpUrl(auditHistoryEndpoint)
             .queryParam("eventTypes", eventTypes)
             .queryParam("page", page)

--- a/src/main/java/uk/gov/digital/ho/proving/income/audit/AuditRecord.java
+++ b/src/main/java/uk/gov/digital/ho/proving/income/audit/AuditRecord.java
@@ -14,8 +14,7 @@ import java.time.LocalDateTime;
 
 @AllArgsConstructor
 @Getter
-public
-class AuditRecord {
+public class AuditRecord {
 
     @JsonProperty(value="id")
     private String id;

--- a/src/main/java/uk/gov/digital/ho/proving/income/audit/AuditRecord.java
+++ b/src/main/java/uk/gov/digital/ho/proving/income/audit/AuditRecord.java
@@ -14,6 +14,7 @@ import java.time.LocalDateTime;
 
 @AllArgsConstructor
 @Getter
+public
 class AuditRecord {
 
     @JsonProperty(value="id")

--- a/src/main/java/uk/gov/digital/ho/proving/income/audit/AuditResult.java
+++ b/src/main/java/uk/gov/digital/ho/proving/income/audit/AuditResult.java
@@ -13,6 +13,7 @@ import java.time.LocalDate;
 @Accessors(fluent = true)
 @EqualsAndHashCode
 @ToString
+public
 class AuditResult {
     private String correlationId;
     private LocalDate date;

--- a/src/main/java/uk/gov/digital/ho/proving/income/audit/AuditResult.java
+++ b/src/main/java/uk/gov/digital/ho/proving/income/audit/AuditResult.java
@@ -13,8 +13,7 @@ import java.time.LocalDate;
 @Accessors(fluent = true)
 @EqualsAndHashCode
 @ToString
-public
-class AuditResult {
+public class AuditResult {
     private String correlationId;
     private LocalDate date;
     private String nino;

--- a/src/main/java/uk/gov/digital/ho/proving/income/audit/AuditResultConsolidator.java
+++ b/src/main/java/uk/gov/digital/ho/proving/income/audit/AuditResultConsolidator.java
@@ -13,8 +13,7 @@ import static uk.gov.digital.ho.proving.income.audit.AuditEventType.INCOME_PROVI
 import static uk.gov.digital.ho.proving.income.audit.AuditResultType.ERROR;
 
 @Component
-public
-class AuditResultConsolidator {
+public class AuditResultConsolidator {
 
     private AuditResultParser auditResultParser;
     private AuditResultTypeComparator auditResultTypeComparator;

--- a/src/main/java/uk/gov/digital/ho/proving/income/audit/AuditResultConsolidator.java
+++ b/src/main/java/uk/gov/digital/ho/proving/income/audit/AuditResultConsolidator.java
@@ -13,6 +13,7 @@ import static uk.gov.digital.ho.proving.income.audit.AuditEventType.INCOME_PROVI
 import static uk.gov.digital.ho.proving.income.audit.AuditResultType.ERROR;
 
 @Component
+public
 class AuditResultConsolidator {
 
     private AuditResultParser auditResultParser;
@@ -29,7 +30,7 @@ class AuditResultConsolidator {
         this.auditResultComparator = auditResultComparator;
     }
 
-    List<AuditResult> auditResultsByCorrelationId(List<AuditRecord> auditRecords) {
+    public List<AuditResult> auditResultsByCorrelationId(List<AuditRecord> auditRecords) {
         Map<String, List<AuditRecord>> recordsByCorrelationId =
             auditRecords.stream().collect(Collectors.groupingBy(AuditRecord::getId));
 
@@ -38,7 +39,7 @@ class AuditResultConsolidator {
             .collect(Collectors.toList());
     }
 
-    List<AuditResultByNino> consolidatedAuditResultsByNino(List<AuditResult> results) {
+    public List<AuditResultByNino> consolidatedAuditResultsByNino(List<AuditResult> results) {
         Map<String, List<AuditResult>> resultsByNino =
             results.stream().collect(Collectors.groupingBy(AuditResult::nino));
 

--- a/src/main/java/uk/gov/digital/ho/proving/income/audit/statistics/PassRateStatisticsService.java
+++ b/src/main/java/uk/gov/digital/ho/proving/income/audit/statistics/PassRateStatisticsService.java
@@ -46,14 +46,18 @@ public class PassRateStatisticsService {
     }
 
     private List<AuditRecord> getAllAuditRecords() {
-        List<AuditRecord> auditRecords;
         List<AuditRecord> allAuditRecords = new ArrayList<>();
+
         int page = 0;
-        do {
-            auditRecords = auditClient.getAuditHistoryPaginated(AUDIT_EVENTS_TO_RETRIEVE, page, requestPageSize);
-            allAuditRecords.addAll(auditRecords);
+        while (addAuditRecords(allAuditRecords, page)) {
             page++;
-        } while (!auditRecords.isEmpty());
+        }
         return allAuditRecords;
+    }
+
+    private boolean addAuditRecords(List<AuditRecord> allAuditRecords, int page) {
+        List<AuditRecord> auditRecords = auditClient.getAuditHistoryPaginated(AUDIT_EVENTS_TO_RETRIEVE, page, requestPageSize);
+        allAuditRecords.addAll(auditRecords);
+        return !auditRecords.isEmpty();
     }
 }

--- a/src/main/java/uk/gov/digital/ho/proving/income/audit/statistics/PassRateStatisticsService.java
+++ b/src/main/java/uk/gov/digital/ho/proving/income/audit/statistics/PassRateStatisticsService.java
@@ -36,7 +36,7 @@ public class PassRateStatisticsService {
     public PassRateStatistics generatePassRateStatistics(LocalDate fromDate, LocalDate toDate) {
         List<AuditRecord> allAuditRecords = getAllAuditRecords();
         List<AuditResultByNino> resultsByNino = consolidateRecords(allAuditRecords);
-        return calculator.result(resultsByNino);
+        return calculator.result(resultsByNino, fromDate, toDate);
     }
 
     private List<AuditResultByNino> consolidateRecords(List<AuditRecord> allAuditRecords) {

--- a/src/main/java/uk/gov/digital/ho/proving/income/audit/statistics/PassRateStatisticsService.java
+++ b/src/main/java/uk/gov/digital/ho/proving/income/audit/statistics/PassRateStatisticsService.java
@@ -59,6 +59,11 @@ public class PassRateStatisticsService {
     private boolean addAuditRecords(List<AuditRecord> allAuditRecords, int page) {
         List<AuditRecord> auditRecords = auditClient.getAuditHistoryPaginated(AUDIT_EVENTS_TO_RETRIEVE, page, requestPageSize);
         allAuditRecords.addAll(auditRecords);
-        return !auditRecords.isEmpty();
+
+        return isFullPage(auditRecords);
+    }
+
+    private boolean isFullPage(List<AuditRecord> auditRecords) {
+        return auditRecords.size() == requestPageSize;
     }
 }

--- a/src/main/java/uk/gov/digital/ho/proving/income/audit/statistics/PassRateStatisticsService.java
+++ b/src/main/java/uk/gov/digital/ho/proving/income/audit/statistics/PassRateStatisticsService.java
@@ -35,14 +35,13 @@ public class PassRateStatisticsService {
 
     public PassRateStatistics generatePassRateStatistics(LocalDate fromDate, LocalDate toDate) {
         List<AuditRecord> allAuditRecords = getAllAuditRecords();
-
-        consolidateRecords(allAuditRecords);
-        return null;
+        List<AuditResultByNino> resultsByNino = consolidateRecords(allAuditRecords);
+        return calculator.result(resultsByNino);
     }
 
-    private void consolidateRecords(List<AuditRecord> allAuditRecords) {
+    private List<AuditResultByNino> consolidateRecords(List<AuditRecord> allAuditRecords) {
         List<AuditResult> byCorrelationId = consolidator.auditResultsByCorrelationId(allAuditRecords);
-        consolidator.consolidatedAuditResultsByNino(byCorrelationId);
+        return consolidator.consolidatedAuditResultsByNino(byCorrelationId);
     }
 
     private List<AuditRecord> getAllAuditRecords() {

--- a/src/main/java/uk/gov/digital/ho/proving/income/audit/statistics/PassRateStatisticsService.java
+++ b/src/main/java/uk/gov/digital/ho/proving/income/audit/statistics/PassRateStatisticsService.java
@@ -1,0 +1,22 @@
+package uk.gov.digital.ho.proving.income.audit.statistics;
+
+import org.springframework.stereotype.Component;
+import uk.gov.digital.ho.proving.income.audit.AuditClient;
+
+import java.time.LocalDate;
+
+@Component
+public class PassRateStatisticsService {
+
+    private final AuditClient auditClient;
+    private final PassStatisticsCalculator calculator;
+
+    public PassRateStatisticsService(AuditClient auditClient, PassStatisticsCalculator calculator) {
+        this.auditClient = auditClient;
+        this.calculator = calculator;
+    }
+
+    public PassRateStatistics generatePassRateStatistics(LocalDate fromDate, LocalDate toDate) {
+        return null;
+    }
+}

--- a/src/main/java/uk/gov/digital/ho/proving/income/audit/statistics/PassRateStatisticsService.java
+++ b/src/main/java/uk/gov/digital/ho/proving/income/audit/statistics/PassRateStatisticsService.java
@@ -1,5 +1,6 @@
 package uk.gov.digital.ho.proving.income.audit.statistics;
 
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
 import uk.gov.digital.ho.proving.income.audit.*;
 
@@ -26,7 +27,8 @@ public class PassRateStatisticsService {
     public PassRateStatisticsService(AuditClient auditClient,
                                      PassStatisticsCalculator calculator,
                                      AuditResultConsolidator consolidator,
-                                     int requestPageSize) { // TODO OJR EE-16843 put in config
+                                     @Value("${audit.history.passratestats.pagesize}") int requestPageSize) {
+
         this.auditClient = auditClient;
         this.calculator = calculator;
         this.consolidator = consolidator;

--- a/src/main/java/uk/gov/digital/ho/proving/income/audit/statistics/PassRateStatisticsService.java
+++ b/src/main/java/uk/gov/digital/ho/proving/income/audit/statistics/PassRateStatisticsService.java
@@ -1,22 +1,59 @@
 package uk.gov.digital.ho.proving.income.audit.statistics;
 
 import org.springframework.stereotype.Component;
-import uk.gov.digital.ho.proving.income.audit.AuditClient;
+import uk.gov.digital.ho.proving.income.audit.*;
 
 import java.time.LocalDate;
+import java.util.ArrayList;
+import java.util.List;
+
+import static java.util.Arrays.asList;
+import static uk.gov.digital.ho.proving.income.audit.AuditEventType.INCOME_PROVING_FINANCIAL_STATUS_REQUEST;
+import static uk.gov.digital.ho.proving.income.audit.AuditEventType.INCOME_PROVING_FINANCIAL_STATUS_RESPONSE;
 
 @Component
 public class PassRateStatisticsService {
 
+    private static final List<AuditEventType> AUDIT_EVENTS_TO_RETRIEVE = asList(
+        INCOME_PROVING_FINANCIAL_STATUS_REQUEST,
+        INCOME_PROVING_FINANCIAL_STATUS_RESPONSE
+    );
     private final AuditClient auditClient;
     private final PassStatisticsCalculator calculator;
+    private final AuditResultConsolidator consolidator;
+    private final int requestPageSize;
 
-    public PassRateStatisticsService(AuditClient auditClient, PassStatisticsCalculator calculator) {
+    public PassRateStatisticsService(AuditClient auditClient,
+                                     PassStatisticsCalculator calculator,
+                                     AuditResultConsolidator consolidator,
+                                     int requestPageSize) { // TODO OJR EE-16843 put in config
         this.auditClient = auditClient;
         this.calculator = calculator;
+        this.consolidator = consolidator;
+        this.requestPageSize = requestPageSize;
     }
 
     public PassRateStatistics generatePassRateStatistics(LocalDate fromDate, LocalDate toDate) {
+        List<AuditRecord> allAuditRecords = getAllAuditRecords();
+
+        consolidateRecords(allAuditRecords);
         return null;
+    }
+
+    private void consolidateRecords(List<AuditRecord> allAuditRecords) {
+        List<AuditResult> byCorrelationId = consolidator.auditResultsByCorrelationId(allAuditRecords);
+        consolidator.consolidatedAuditResultsByNino(byCorrelationId);
+    }
+
+    private List<AuditRecord> getAllAuditRecords() {
+        List<AuditRecord> auditRecords;
+        List<AuditRecord> allAuditRecords = new ArrayList<>();
+        int page = 0;
+        do {
+            auditRecords = auditClient.getAuditHistoryPaginated(AUDIT_EVENTS_TO_RETRIEVE, page, requestPageSize);
+            allAuditRecords.addAll(auditRecords);
+            page++;
+        } while (!auditRecords.isEmpty());
+        return allAuditRecords;
     }
 }

--- a/src/main/java/uk/gov/digital/ho/proving/income/audit/statistics/PassStatisticsCalculator.java
+++ b/src/main/java/uk/gov/digital/ho/proving/income/audit/statistics/PassStatisticsCalculator.java
@@ -1,5 +1,6 @@
 package uk.gov.digital.ho.proving.income.audit.statistics;
 
+import org.springframework.stereotype.Component;
 import uk.gov.digital.ho.proving.income.audit.AuditResultByNino;
 import uk.gov.digital.ho.proving.income.audit.AuditResultType;
 import uk.gov.digital.ho.proving.income.audit.statistics.PassRateStatistics.PassRateStatisticsBuilder;
@@ -13,6 +14,7 @@ import static java.util.stream.Collectors.groupingBy;
 import static java.util.stream.Collectors.toList;
 import static uk.gov.digital.ho.proving.income.audit.AuditResultType.*;
 
+@Component
 class PassStatisticsCalculator {
 
     PassRateStatistics result(List<AuditResultByNino> records, LocalDate fromDate, LocalDate toDate) {

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -70,4 +70,4 @@ audit.history.months=6
 audit.history.endpoint=${pttg.audit.url}/history
 audit.archive.endpoint=${pttg.audit.url}/archive
 
-audit.history.passratestats.pagesize=20
+audit.history.passratestats.pagesize=100

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -70,3 +70,4 @@ audit.history.months=6
 audit.history.endpoint=${pttg.audit.url}/history
 audit.archive.endpoint=${pttg.audit.url}/archive
 
+audit.history.passratestats.pagesize=20

--- a/src/test/java/uk/gov/digital/ho/proving/income/audit/AuditClientTest.java
+++ b/src/test/java/uk/gov/digital/ho/proving/income/audit/AuditClientTest.java
@@ -146,12 +146,12 @@ public class AuditClientTest {
 
     @Test
     public void getAuditHistoryPaginated_givenParams_expectedUri() {
-        List<AuditEventType> eventTypes = Arrays.asList(INCOME_PROVING_FINANCIAL_STATUS_REQUEST, INCOME_PROVING_FINANCIAL_STATUS_RESPONSE);
-        int page = 23;
-        int size = 8;
         when(mockRestTemplate.exchange(captorUri.capture(), eq(GET), any(HttpEntity.class), eq(new ParameterizedTypeReference<List<AuditRecord>>() {})))
             .thenReturn(ResponseEntity.ok(emptyList()));
 
+        List<AuditEventType> eventTypes = Arrays.asList(INCOME_PROVING_FINANCIAL_STATUS_REQUEST, INCOME_PROVING_FINANCIAL_STATUS_RESPONSE);
+        int page = 23;
+        int size = 8;
         auditClient.getAuditHistoryPaginated(eventTypes, page, size);
 
         URI uri = captorUri.getValue();
@@ -162,16 +162,19 @@ public class AuditClientTest {
     @Test
     public void getAuditHistoryPaginated_givenResponse_returnRecords() {
         List<AuditRecord> results = emptyList();
+        stubResponse(results);
+
+        List<AuditEventType> someEventTypes = Arrays.asList(INCOME_PROVING_FINANCIAL_STATUS_REQUEST, INCOME_PROVING_FINANCIAL_STATUS_RESPONSE);
+        int somePage = 1;
+        int someSize = 1;
+
+        assertThat(auditClient.getAuditHistoryPaginated(someEventTypes, somePage, someSize))
+            .isEqualTo(results);
+    }
+
+    private void stubResponse(List<AuditRecord> results) {
         ResponseEntity<List<AuditRecord>> response = ResponseEntity.ok(results);
-
-        when(mockRestTemplate.exchange(any(URI.class), eq(GET), any(HttpEntity.class), eq(new ParameterizedTypeReference<List<AuditRecord>>() {})))
+        when(mockRestTemplate.exchange(captorUri.capture(), eq(GET), any(HttpEntity.class), eq(new ParameterizedTypeReference<List<AuditRecord>>() {})))
             .thenReturn(response);
-
-        List<AuditEventType> eventTypes = Arrays.asList(INCOME_PROVING_FINANCIAL_STATUS_REQUEST, INCOME_PROVING_FINANCIAL_STATUS_RESPONSE);
-        int somePage = 23;
-        int someSize = 8;
-        List<AuditRecord> returnedResults = auditClient.getAuditHistoryPaginated(eventTypes, somePage, someSize);
-
-        assertThat(returnedResults).isEqualTo(results);
     }
 }

--- a/src/test/java/uk/gov/digital/ho/proving/income/audit/AuditClientTest.java
+++ b/src/test/java/uk/gov/digital/ho/proving/income/audit/AuditClientTest.java
@@ -147,7 +147,7 @@ public class AuditClientTest {
         List<AuditEventType> eventTypes = Arrays.asList(INCOME_PROVING_FINANCIAL_STATUS_REQUEST, INCOME_PROVING_FINANCIAL_STATUS_RESPONSE);
         int page = 23;
         int size = 8;
-        when(mockRestTemplate.exchange(any(URI.class), eq(GET), any(HttpEntity.class), eq(new ParameterizedTypeReference<List<AuditRecord>>() {})))
+        when(mockRestTemplate.exchange(captorUri.capture(), eq(GET), any(HttpEntity.class), eq(new ParameterizedTypeReference<List<AuditRecord>>() {})))
             .thenReturn(ResponseEntity.ok(emptyList()));
 
         auditClient.getAuditHistoryPaginated(eventTypes, page, size);

--- a/src/test/java/uk/gov/digital/ho/proving/income/audit/AuditClientTest.java
+++ b/src/test/java/uk/gov/digital/ho/proving/income/audit/AuditClientTest.java
@@ -156,7 +156,13 @@ public class AuditClientTest {
 
         URI uri = captorUri.getValue();
         assertThat(uri).hasHost(SOME_HISTORY_ENDPOINT.replace("http://", ""));
-        assertThat(uri).hasQuery(String.format("eventTypes=%s&page=%s&size=%s", eventTypes.toString(), page, size));
+
+        String[] queryStringComponents = uri.getQuery().split("&");
+        assertThat(queryStringComponents).containsExactlyInAnyOrder(
+            "eventTypes=" + eventTypes,
+            "page=" + page,
+            "size=" + size
+        );
     }
 
     @Test

--- a/src/test/java/uk/gov/digital/ho/proving/income/audit/FileUtils.java
+++ b/src/test/java/uk/gov/digital/ho/proving/income/audit/FileUtils.java
@@ -9,6 +9,8 @@ import org.springframework.stereotype.Component;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Paths;
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
 
 @Component
 @Configuration
@@ -38,12 +40,22 @@ class FileUtils {
         }
     }
 
+    public String buildRequest(String correlationId, LocalDateTime dateTime, String nino) {
+        String formattedDateTime = dateTime.format(DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss.SSS"));
+        return buildRequest(correlationId, formattedDateTime, nino);
+    }
+
     public String buildRequest(String correlationId, String dateTime, String nino) {
         String requestTemplate = loadJsonResource(auditRecordRequestTemplate);
         requestTemplate = requestTemplate.replaceAll("\\$\\{correlation-id}", correlationId);
         requestTemplate = requestTemplate.replaceAll("\\$\\{date-time}", dateTime);
         requestTemplate = requestTemplate.replaceAll("\\$\\{nino}", nino);
         return requestTemplate;
+    }
+
+    public String buildResponse(String correlationId, LocalDateTime dateTime, String nino, String pass) {
+        String formattedDateTime = dateTime.format(DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss.SSS"));
+        return buildResponse(correlationId, formattedDateTime, nino, pass);
     }
 
     public String buildResponse(String correlationId, String dateTime, String nino, String pass) {
@@ -53,6 +65,11 @@ class FileUtils {
         responseTemplate = responseTemplate.replaceAll("\\$\\{nino}", nino);
         responseTemplate = responseTemplate.replaceAll("\\$\\{pass}", pass);
         return responseTemplate;
+    }
+
+    public String buildResponseNotFound(String correlationId, LocalDateTime dateTime) {
+        String formattedDateTime = dateTime.format(DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss.SSS"));
+        return buildResponseNotFound(correlationId, formattedDateTime);
     }
 
     public String buildResponseNotFound(String correlationId, String dateTime) {

--- a/src/test/java/uk/gov/digital/ho/proving/income/audit/FileUtils.java
+++ b/src/test/java/uk/gov/digital/ho/proving/income/audit/FileUtils.java
@@ -12,6 +12,7 @@ import java.nio.file.Paths;
 
 @Component
 @Configuration
+public
 class FileUtils {
 
     private ObjectMapper objectMapper;
@@ -37,7 +38,7 @@ class FileUtils {
         }
     }
 
-    String buildRequest(String correlationId, String dateTime, String nino) {
+    public String buildRequest(String correlationId, String dateTime, String nino) {
         String requestTemplate = loadJsonResource(auditRecordRequestTemplate);
         requestTemplate = requestTemplate.replaceAll("\\$\\{correlation-id}", correlationId);
         requestTemplate = requestTemplate.replaceAll("\\$\\{date-time}", dateTime);
@@ -45,7 +46,7 @@ class FileUtils {
         return requestTemplate;
     }
 
-    String buildResponse(String correlationId, String dateTime, String nino, String pass) {
+    public String buildResponse(String correlationId, String dateTime, String nino, String pass) {
         String responseTemplate = loadJsonResource(auditRecordResponseTemplate);
         responseTemplate = responseTemplate.replaceAll("\\$\\{correlation-id}", correlationId);
         responseTemplate = responseTemplate.replaceAll("\\$\\{date-time}", dateTime);
@@ -54,7 +55,7 @@ class FileUtils {
         return responseTemplate;
     }
 
-    String buildResponseNotFound(String correlationId, String dateTime) {
+    public String buildResponseNotFound(String correlationId, String dateTime) {
         String responseTemplate = loadJsonResource(auditRecordResourceNotFoundTemplate);
         responseTemplate = responseTemplate.replaceAll("\\$\\{correlation-id}", correlationId);
         responseTemplate = responseTemplate.replaceAll("\\$\\{date-time}", dateTime);

--- a/src/test/java/uk/gov/digital/ho/proving/income/audit/FileUtils.java
+++ b/src/test/java/uk/gov/digital/ho/proving/income/audit/FileUtils.java
@@ -14,8 +14,7 @@ import java.time.format.DateTimeFormatter;
 
 @Component
 @Configuration
-public
-class FileUtils {
+public class FileUtils {
 
     private ObjectMapper objectMapper;
 

--- a/src/test/java/uk/gov/digital/ho/proving/income/audit/statistics/PassRateStatisticsServiceIT.java
+++ b/src/test/java/uk/gov/digital/ho/proving/income/audit/statistics/PassRateStatisticsServiceIT.java
@@ -17,6 +17,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.hamcrest.Matchers.containsString;
 import static org.springframework.http.HttpMethod.GET;
 import static org.springframework.http.MediaType.APPLICATION_JSON;
+import static org.springframework.test.web.client.ExpectedCount.times;
 import static org.springframework.test.web.client.match.MockRestRequestMatchers.method;
 import static org.springframework.test.web.client.match.MockRestRequestMatchers.requestTo;
 import static org.springframework.test.web.client.response.MockRestResponseCreators.withSuccess;
@@ -30,6 +31,7 @@ public class PassRateStatisticsServiceIT {
 
     private static final LocalDate FROM_DATE = LocalDate.of(2018, Month.AUGUST, 1);
     private static final LocalDate TO_DATE = LocalDate.of(2018, Month.AUGUST, 31);
+    private static final String EMPTY_RESPONSE = "[ ]";
 
     @Autowired
     private RestTemplate restTemplate;
@@ -47,13 +49,12 @@ public class PassRateStatisticsServiceIT {
 
     @Test
     public void passRateStatistics_noData_statisticsAllZero() {
-        String auditHistory = "[ ]";
         mockAuditService
             .expect(requestTo(containsString("/history")))
             .andExpect(requestTo(containsString("page=0")))
             .andExpect(requestTo(containsString("size=5")))
             .andExpect(method(GET))
-            .andRespond(withSuccess(auditHistory, APPLICATION_JSON));
+            .andRespond(withSuccess(EMPTY_RESPONSE, APPLICATION_JSON));
 
         PassRateStatistics actualStatistics = passRateStatisticsService.generatePassRateStatistics(FROM_DATE, TO_DATE);
         PassRateStatistics expectedStatistics = new PassRateStatistics(FROM_DATE, TO_DATE, 0, 0, 0, 0, 0);
@@ -62,6 +63,60 @@ public class PassRateStatisticsServiceIT {
 
     @Test
     public void passRateStatistics_singleResponseWithData_populateStatistics() {
-        String nino1RequestPass = fileUtils.
+        String nino1PassRequest = fileUtils.buildRequest("correlationID 1", "2018-08-01 09:00:00.000", "nino 1");
+        String nino1PassResponse = fileUtils.buildResponse("correlationID 1", "2018-08-01 09:00:01.000", "nino 1", "true");
+
+        String nino2FailRequest = fileUtils.buildRequest("correlationID 2", "2018-08-01 09:00:00.000", "nino 2");
+        String nino2FailResponse = fileUtils.buildResponse("correlationID 2", "2018-08-01 09:00:01.000", "nino 2", "false");
+
+        String auditHistory = String.format("[%s]", String.join(", ", nino1PassRequest, nino1PassResponse, nino2FailRequest, nino2FailResponse));
+
+        mockAuditServiceResponses(auditHistory, EMPTY_RESPONSE);
+
+        PassRateStatistics actualStatistics = passRateStatisticsService.generatePassRateStatistics(FROM_DATE, TO_DATE);
+        PassRateStatistics expectedStatistics = new PassRateStatistics(FROM_DATE, TO_DATE, 2, 1, 1, 0, 0);
+        assertThat(actualStatistics).isEqualTo(expectedStatistics);
+    }
+
+    @Test
+    public void passRateStatistics_responsesSplitBetweenPages_populateStatistics() {
+        String nino1PassRequest = fileUtils.buildRequest("correlationID 1", "2018-08-01 09:00:00.000", "nino 1");
+        String nino1PassResponse = fileUtils.buildResponse("correlationID 1", "2018-08-01 09:00:01.000", "nino 1", "true");
+
+        String nino2FailRequest = fileUtils.buildRequest("correlationID 2", "2018-08-01 09:00:00.000", "nino 2");
+        String nino2FailResponse = fileUtils.buildResponse("correlationID 2", "2018-08-01 09:00:01.000", "nino 2", "false");
+
+        String nino3NotFoundRequest = fileUtils.buildRequest("correlationID 3", "2018-08-02 10:00:00.000", "nino 3");
+        String nino3NotFoundResponse = fileUtils.buildResponseNotFound("correlationID 3", "2018-08-02 10:00:00.500");
+
+        String nino4PassRequest = fileUtils.buildRequest("correlationID 4", "2018-08-03 11:00:00.000", "nino 4");
+        String nino4PassResponse = fileUtils.buildResponse("correlationID 4", "2018-08-03 11:00:00.000", "nino 4", "true");
+
+        String nino5PassRequest = fileUtils.buildRequest("correlationID 5", "2018-08-03 11:30:00.000", "nino 5");
+        String nino5PassResponse = fileUtils.buildResponse("correlationID 5", "2018-08-03 11:31:00.000", "nino 5", "true");
+
+        String response1 = String.format("[%s]", String.join(", ", nino1PassRequest, nino2FailResponse, nino3NotFoundResponse, nino5PassRequest, nino5PassResponse));
+        String response2 = String.format("[%s]", String.join(", ", nino4PassResponse, nino3NotFoundRequest, nino4PassRequest, nino2FailRequest, nino1PassResponse));
+        mockAuditServiceResponses(response1, response2, EMPTY_RESPONSE);
+
+        PassRateStatistics actualStatistics = passRateStatisticsService.generatePassRateStatistics(FROM_DATE, TO_DATE);
+        PassRateStatistics expectedStatistics = new PassRateStatistics(FROM_DATE, TO_DATE, 5, 3, 1, 1, 0);
+        assertThat(actualStatistics).isEqualTo(expectedStatistics);
+    }
+
+    // TODO OJR EE-16843: Test best result kept
+    // TODO OJR EE-16843: Test no response counts error
+    // TODO OJR EE-16843: Test out of date range ignored
+
+
+    private void mockAuditServiceResponses(String... responses) {
+        for (int i = 0; i < responses.length; i++) {
+            String response = responses[i];
+            mockAuditService
+                .expect(requestTo(containsString("/history")))
+                .andExpect(requestTo(containsString("page=" + i)))
+                .andRespond(withSuccess(response, APPLICATION_JSON));
+
+        }
     }
 }

--- a/src/test/java/uk/gov/digital/ho/proving/income/audit/statistics/PassRateStatisticsServiceIT.java
+++ b/src/test/java/uk/gov/digital/ho/proving/income/audit/statistics/PassRateStatisticsServiceIT.java
@@ -12,6 +12,7 @@ import uk.gov.digital.ho.proving.income.audit.FileUtils;
 
 import java.time.LocalDate;
 import java.time.Month;
+import java.time.format.DateTimeFormatter;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.hamcrest.Matchers.containsString;
@@ -104,9 +105,74 @@ public class PassRateStatisticsServiceIT {
         assertThat(actualStatistics).isEqualTo(expectedStatistics);
     }
 
-    // TODO OJR EE-16843: Test best result kept
-    // TODO OJR EE-16843: Test no response counts error
-    // TODO OJR EE-16843: Test out of date range ignored
+    @Test
+    public void passRateStatistics_multipleResults_bestResultsCountToStats() {
+        // Nino1 has a best result of pass
+        String nino1FailRequest = fileUtils.buildRequest("correlationID 1", "2018-08-01 09:00:00.000", "nino 1");
+        String nino1FailResponse = fileUtils.buildResponse("correlationID 1", "2018-08-01 09:01:00.000", "nino 1", "false");
+        String nino1PassRequest = fileUtils.buildRequest("correlationID 2", "2018-08-01 09:02:00.000", "nino 1");
+        String nino1PassResponse = fileUtils.buildResponse("correlationID 2", "2018-08-01 09:03:00.000", "nino 1", "true");
+
+        // Nino2 has a best result of failed
+        String nino2FailRequest = fileUtils.buildRequest("correlationID 3", "2018-08-01 09:04:00.000", "nino2");
+        String nino2FailResponse = fileUtils.buildResponse("correlationID 3", "2018-08-01 09:05:00.000", "nino2", "false");
+        String nino2NotFoundRequest = fileUtils.buildRequest("correlationID 4", "2018-08-01 09:06:00.000", "nino2");
+        String nino2NotFoundResponse = fileUtils.buildResponseNotFound("correlationID 4", "2018-08-01 09:07:00.000");
+
+        // Nino3 has a best result of not found
+
+        // no corresponding response so this is an error
+        String nino3ErrorRequest = fileUtils.buildRequest("correlationID 5", "2018-08-01 09:08:00.000", "nino3");
+        String nino3NotFoundRequest = fileUtils.buildRequest("correlationID 6", "2018-08-01 09:09:00.000", "nino3");
+        String nino3NotFoundResponse = fileUtils.buildResponseNotFound("correlationID 6", "2018-08-01 09:10:00.000");
+
+        // Nino4 has a best result of error
+
+        // no corresponding response so this is an error
+        String nino4ErrorRequest = fileUtils.buildRequest("correlationID 7", "2018-08-01 09:11:00.000", "nino 4");
+
+        String auditHistoryResponse1 = String.format("[%s]", String.join(", ", nino1FailRequest, nino1FailResponse, nino2FailRequest, nino2NotFoundRequest, nino4ErrorRequest));
+        String auditHistoryResponse2 = String.format("[%s]", String.join(", ", nino1PassResponse, nino1PassRequest, nino2FailResponse, nino3ErrorRequest, nino3NotFoundResponse));
+        String auditHistoryResponse3 = String.format("[%s]", String.join(", ", nino2NotFoundResponse, nino3NotFoundRequest));
+
+        mockAuditServiceResponses(auditHistoryResponse1, auditHistoryResponse2, auditHistoryResponse3, EMPTY_RESPONSE);
+
+        PassRateStatistics expectedPassRateStatistics = new PassRateStatistics(FROM_DATE, TO_DATE, 4, 1, 1, 1, 1);
+        assertThat(passRateStatisticsService.generatePassRateStatistics(FROM_DATE, TO_DATE))
+            .isEqualTo(expectedPassRateStatistics);
+
+    }
+
+    @Test
+    public void passRateStatistics_requestsOutOfRange_notCounted() {
+        // Both request and response too early - should NOT be counted
+        String passRequestTooEarly = fileUtils.buildRequest("correlationID 1", FROM_DATE.minusDays(1).atTime(9, 0).format(DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss.SSS")), "nino1");
+        String passResponseTooEarly = fileUtils.buildResponse("correlationID 1", FROM_DATE.minusDays(1).atTime(9, 1).format(DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss.SSS")), "nino1", "true");
+
+        // Both request and response too late - should NOT be counted
+        String failRequestTooLate = fileUtils.buildRequest("correlationID 2", TO_DATE.plusDays(1).atTime(9, 0).format(DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss.SSS")), "nino2");
+        String failResponseTooLate = fileUtils.buildResponse("correlationID 2", TO_DATE.plusDays(1).atTime(9, 0).format(DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss.SSS")), "nino2", "false");
+
+        // Request too early but response in range - should be counted
+        String passRequest2TooEarly = fileUtils.buildRequest("correlationID 3", FROM_DATE.minusDays(1).atTime(9, 0).format(DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss.SSS")), "nino3");
+        String passResponse2InRange = fileUtils.buildResponse("correlationID 3", FROM_DATE.atTime(9, 0).format(DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss.SSS")), "nino3", "true");
+
+        // Request in range but response too late - should NOT be counted
+        String failRequest2InRange = fileUtils.buildRequest("correlationID 4", TO_DATE.atTime(9, 0).format(DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss.SSS")), "nino4");
+        String failResponse2InRange = fileUtils.buildResponse("correlationID 4", TO_DATE.plusDays(1).atTime(9, 0).format(DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss.SSS")), "nino4", "false");
+
+        // Request and response last day - counted
+        String notFoundRequestLastDay = fileUtils.buildRequest("correlationID 5", TO_DATE.atTime(23, 58).format(DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss.SSS")), "nino5");
+        String notFoundResponseLastDay = fileUtils.buildResponseNotFound("correlationID 5", TO_DATE.atTime(23, 59).format(DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss.SSS")));
+
+        String auditHistoryResponse1 = String.format("[%s]", String.join(", ", passRequestTooEarly, failRequestTooLate, failResponseTooLate, notFoundRequestLastDay, notFoundResponseLastDay));
+        String auditHistoryResponse2 = String.format("[%s]", String.join(", ", passRequest2TooEarly, failResponse2InRange, failRequest2InRange, passResponse2InRange, passResponseTooEarly));
+        mockAuditServiceResponses(auditHistoryResponse1, auditHistoryResponse2, EMPTY_RESPONSE);
+
+        PassRateStatistics expectedStatistics = new PassRateStatistics(FROM_DATE, TO_DATE, 1, 0, 0, 1, 0);
+        assertThat(passRateStatisticsService.generatePassRateStatistics(FROM_DATE, TO_DATE))
+            .isEqualTo(expectedStatistics);
+    }
 
 
     private void mockAuditServiceResponses(String... responses) {

--- a/src/test/java/uk/gov/digital/ho/proving/income/audit/statistics/PassRateStatisticsServiceIT.java
+++ b/src/test/java/uk/gov/digital/ho/proving/income/audit/statistics/PassRateStatisticsServiceIT.java
@@ -1,0 +1,67 @@
+package uk.gov.digital.ho.proving.income.audit.statistics;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.junit4.SpringRunner;
+import org.springframework.test.web.client.MockRestServiceServer;
+import org.springframework.web.client.RestTemplate;
+import uk.gov.digital.ho.proving.income.audit.FileUtils;
+
+import java.time.LocalDate;
+import java.time.Month;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.hamcrest.Matchers.containsString;
+import static org.springframework.http.HttpMethod.GET;
+import static org.springframework.http.MediaType.APPLICATION_JSON;
+import static org.springframework.test.web.client.match.MockRestRequestMatchers.method;
+import static org.springframework.test.web.client.match.MockRestRequestMatchers.requestTo;
+import static org.springframework.test.web.client.response.MockRestResponseCreators.withSuccess;
+
+@RunWith(SpringRunner.class)
+@SpringBootTest(
+    properties = {
+        "audit.history.passratestats.pagesize=5"
+    })
+public class PassRateStatisticsServiceIT {
+
+    private static final LocalDate FROM_DATE = LocalDate.of(2018, Month.AUGUST, 1);
+    private static final LocalDate TO_DATE = LocalDate.of(2018, Month.AUGUST, 31);
+
+    @Autowired
+    private RestTemplate restTemplate;
+    @Autowired
+    private PassRateStatisticsService passRateStatisticsService;
+    @Autowired
+    private FileUtils fileUtils;
+
+    private MockRestServiceServer mockAuditService;
+
+    @Before
+    public void setUp() {
+        mockAuditService = MockRestServiceServer.bindTo(restTemplate).ignoreExpectOrder(true).build();
+    }
+
+    @Test
+    public void passRateStatistics_noData_statisticsAllZero() {
+        String auditHistory = "[ ]";
+        mockAuditService
+            .expect(requestTo(containsString("/history")))
+            .andExpect(requestTo(containsString("page=0")))
+            .andExpect(requestTo(containsString("size=5")))
+            .andExpect(method(GET))
+            .andRespond(withSuccess(auditHistory, APPLICATION_JSON));
+
+        PassRateStatistics actualStatistics = passRateStatisticsService.generatePassRateStatistics(FROM_DATE, TO_DATE);
+        PassRateStatistics expectedStatistics = new PassRateStatistics(FROM_DATE, TO_DATE, 0, 0, 0, 0, 0);
+        assertThat(actualStatistics).isEqualTo(expectedStatistics);
+    }
+
+    @Test
+    public void passRateStatistics_singleResponseWithData_populateStatistics() {
+        String nino1RequestPass = fileUtils.
+    }
+}

--- a/src/test/java/uk/gov/digital/ho/proving/income/audit/statistics/PassRateStatisticsServiceIT.java
+++ b/src/test/java/uk/gov/digital/ho/proving/income/audit/statistics/PassRateStatisticsServiceIT.java
@@ -70,7 +70,7 @@ public class PassRateStatisticsServiceIT {
 
         String auditHistory = joinAuditRecordsAsJsonList(nino1PassRequest, nino1PassResponse, nino2FailRequest, nino2FailResponse);
 
-        mockAuditServiceResponses(auditHistory, EMPTY_RESPONSE);
+        mockAuditServiceResponses(auditHistory);
 
         PassRateStatistics actualStatistics = passRateStatisticsService.generatePassRateStatistics(FROM_DATE, TO_DATE);
         PassRateStatistics expectedStatistics = new PassRateStatistics(FROM_DATE, TO_DATE, 2, 1, 1, 0, 0);
@@ -133,7 +133,7 @@ public class PassRateStatisticsServiceIT {
         String auditHistoryResponse2 = joinAuditRecordsAsJsonList(nino1PassResponse, nino1PassRequest, nino2FailResponse, nino3ErrorRequest, nino3NotFoundResponse);
         String auditHistoryResponse3 = joinAuditRecordsAsJsonList(nino2NotFoundResponse, nino3NotFoundRequest);
 
-        mockAuditServiceResponses(auditHistoryResponse1, auditHistoryResponse2, auditHistoryResponse3, EMPTY_RESPONSE);
+        mockAuditServiceResponses(auditHistoryResponse1, auditHistoryResponse2, auditHistoryResponse3);
 
         PassRateStatistics expectedPassRateStatistics = new PassRateStatistics(FROM_DATE, TO_DATE, 4, 1, 1, 1, 1);
         assertThat(passRateStatisticsService.generatePassRateStatistics(FROM_DATE, TO_DATE))

--- a/src/test/java/uk/gov/digital/ho/proving/income/audit/statistics/PassRateStatisticsServiceTest.java
+++ b/src/test/java/uk/gov/digital/ho/proving/income/audit/statistics/PassRateStatisticsServiceTest.java
@@ -1,17 +1,25 @@
 package uk.gov.digital.ho.proving.income.audit.statistics;
 
+import com.fasterxml.jackson.databind.JsonNode;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnitRunner;
-import uk.gov.digital.ho.proving.income.audit.AuditClient;
-import uk.gov.digital.ho.proving.income.audit.AuditResultByNino;
+import uk.gov.digital.ho.proving.income.audit.*;
 
 import java.time.LocalDate;
+import java.time.LocalDateTime;
 import java.util.List;
 
-import static org.mockito.Mockito.verify;
+import static java.util.Arrays.asList;
+import static java.util.Collections.emptyList;
+import static java.util.Collections.singletonList;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.anyList;
+import static org.mockito.Mockito.*;
+import static uk.gov.digital.ho.proving.income.audit.AuditEventType.INCOME_PROVING_FINANCIAL_STATUS_REQUEST;
+import static uk.gov.digital.ho.proving.income.audit.AuditEventType.INCOME_PROVING_FINANCIAL_STATUS_RESPONSE;
 
 @RunWith(MockitoJUnitRunner.class)
 public class PassRateStatisticsServiceTest {
@@ -19,23 +27,89 @@ public class PassRateStatisticsServiceTest {
     @Mock
     private AuditClient mockAuditClient;
     @Mock
+    private AuditResultConsolidator mockConsolidator;
+    @Mock
     private PassStatisticsCalculator mockPassStatisticsCalculator;
 
     private PassRateStatisticsService service;
 
+    private static final LocalDate SOME_DATE = LocalDate.now();
+    private static final int PAGE_SIZE = 1;
+    private static final LocalDateTime SOME_DATE_TIME = LocalDateTime.now();
+    private static final AuditEventType SOME_AUDIT_EVENT_TYPE = INCOME_PROVING_FINANCIAL_STATUS_REQUEST;
+    private static final JsonNode SOME_JSON = null;
+
     @Before
     public void setUp() {
-        service = new PassRateStatisticsService(mockAuditClient, mockPassStatisticsCalculator);
+        service = new PassRateStatisticsService(mockAuditClient, mockPassStatisticsCalculator, mockConsolidator, PAGE_SIZE);
     }
 
     @Test
-    public void generatePassRateStatistics_givenDates_callCollaborators() {
-        LocalDate fromDate = LocalDate.MIN;
-        LocalDate toDate = LocalDate.MAX;
-        List<AuditResultByNino> records;
-//        given some records returned
+    public void generatePassStatistics_givenPageSize_requestedPageSize() {
+        int pageSize = 200;
+        service = new PassRateStatisticsService(mockAuditClient, mockPassStatisticsCalculator, mockConsolidator, pageSize);
 
-        service.generatePassRateStatistics(fromDate, toDate);
-//        verify(mockPassStatisticsCalculator).result(records);
+        service.generatePassRateStatistics(SOME_DATE, SOME_DATE);
+        verify(mockAuditClient).getAuditHistoryPaginated(anyList(), anyInt(), eq(pageSize));
+    }
+
+    @Test
+    public void generatePassStatistics_firstRequest_firstPageZeroIndexed() {
+        service.generatePassRateStatistics(SOME_DATE, SOME_DATE);
+        verify(mockAuditClient).getAuditHistoryPaginated(anyList(), eq(0), anyInt());
+    }
+
+    @Test
+    public void generatePassStatisitics_anyParams_expectedEventTypes() {
+        service.generatePassRateStatistics(SOME_DATE, SOME_DATE);
+        List<AuditEventType> eventTypes = asList(INCOME_PROVING_FINANCIAL_STATUS_REQUEST, INCOME_PROVING_FINANCIAL_STATUS_RESPONSE);
+        verify(mockAuditClient).getAuditHistoryPaginated(eq(eventTypes), anyInt(), anyInt());
+    }
+
+    @Test
+    public void generatePassStatistics_noResults_noMoreRequests() {
+        when(mockAuditClient.getAuditHistoryPaginated(anyList(), anyInt(), anyInt()))
+            .thenReturn(emptyList());
+
+        service.generatePassRateStatistics(SOME_DATE, SOME_DATE);
+        verify(mockAuditClient, times(1))
+            .getAuditHistoryPaginated(anyList(), anyInt(), anyInt());
+    }
+
+    @Test
+    public void generatePassStatistics_resultsFromAuditSerivce_requestAnotherPage() {
+        AuditRecord someAuditRecord = new AuditRecord("some id", SOME_DATE_TIME, "some email", SOME_AUDIT_EVENT_TYPE, SOME_JSON, "some nino");
+
+        when(mockAuditClient.getAuditHistoryPaginated(anyList(), eq(0), eq(PAGE_SIZE)))
+            .thenReturn(singletonList(someAuditRecord));
+
+        service.generatePassRateStatistics(SOME_DATE, SOME_DATE);
+        verify(mockAuditClient)
+            .getAuditHistoryPaginated(anyList(), eq(0), eq(PAGE_SIZE));
+        verify(mockAuditClient)
+            .getAuditHistoryPaginated(anyList(), eq(1), eq(PAGE_SIZE));
+    }
+
+    @Test
+    public void generatePassStatistics_givenResultsFromAuditService_passedToConsolidator() {
+        AuditRecord someAuditRecord = new AuditRecord("some id", SOME_DATE_TIME, "some email", SOME_AUDIT_EVENT_TYPE, SOME_JSON, "some nino");
+        List<AuditRecord> returnedAuditRecords = singletonList(someAuditRecord);
+
+        when(mockAuditClient.getAuditHistoryPaginated(anyList(), eq(0), eq(PAGE_SIZE)))
+            .thenReturn(returnedAuditRecords);
+
+        service.generatePassRateStatistics(SOME_DATE, SOME_DATE);
+        verify(mockConsolidator).auditResultsByCorrelationId(returnedAuditRecords);
+    }
+
+    @Test
+    public void generatePassStatistics_givenResultsByCorrelationIdFromConsolidator_consolidateByNino() {
+        AuditResultType someAuditResultType = AuditResultType.PASS;
+        List<AuditResult> byCorrelationId = singletonList(new AuditResult("some correlation id", SOME_DATE, "some nino", someAuditResultType));
+        when(mockConsolidator.auditResultsByCorrelationId(anyList()))
+            .thenReturn(byCorrelationId);
+
+        service.generatePassRateStatistics(SOME_DATE, SOME_DATE);
+        verify(mockConsolidator).consolidatedAuditResultsByNino(byCorrelationId);
     }
 }

--- a/src/test/java/uk/gov/digital/ho/proving/income/audit/statistics/PassRateStatisticsServiceTest.java
+++ b/src/test/java/uk/gov/digital/ho/proving/income/audit/statistics/PassRateStatisticsServiceTest.java
@@ -34,7 +34,7 @@ public class PassRateStatisticsServiceTest {
 
     private PassRateStatisticsService service;
 
-    private static final int PAGE_SIZE = 1;
+    private static final int PAGE_SIZE = 2;
 
     private static final long SOME_LONG = 3;
     private static final LocalDate SOME_DATE = LocalDate.MAX;
@@ -85,7 +85,21 @@ public class PassRateStatisticsServiceTest {
     }
 
     @Test
-    public void generatePassStatistics_resultsFromAuditService_requestAnotherPage() {
+    public void generatePassStatistics_fullPageOfResultsFromAuditService_requestAnotherPage() {
+        AuditRecord someAuditRecord = new AuditRecord("some id", SOME_DATE_TIME, "some email", SOME_AUDIT_EVENT_TYPE, SOME_JSON, "some nino");
+
+        when(mockAuditClient.getAuditHistoryPaginated(anyList(), eq(0), eq(PAGE_SIZE)))
+            .thenReturn(asList(someAuditRecord, someAuditRecord));
+
+        service.generatePassRateStatistics(SOME_DATE, SOME_DATE);
+        verify(mockAuditClient)
+            .getAuditHistoryPaginated(anyList(), eq(0), eq(PAGE_SIZE));
+        verify(mockAuditClient)
+            .getAuditHistoryPaginated(anyList(), eq(1), eq(PAGE_SIZE));
+    }
+
+    @Test
+    public void generatePassStatistics_partialOfResultsFromAuditService_noMoreRequests() {
         AuditRecord someAuditRecord = new AuditRecord("some id", SOME_DATE_TIME, "some email", SOME_AUDIT_EVENT_TYPE, SOME_JSON, "some nino");
 
         when(mockAuditClient.getAuditHistoryPaginated(anyList(), eq(0), eq(PAGE_SIZE)))
@@ -94,8 +108,7 @@ public class PassRateStatisticsServiceTest {
         service.generatePassRateStatistics(SOME_DATE, SOME_DATE);
         verify(mockAuditClient)
             .getAuditHistoryPaginated(anyList(), eq(0), eq(PAGE_SIZE));
-        verify(mockAuditClient)
-            .getAuditHistoryPaginated(anyList(), eq(1), eq(PAGE_SIZE));
+        verifyNoMoreInteractions(mockAuditClient);
     }
 
     /***************************************

--- a/src/test/java/uk/gov/digital/ho/proving/income/audit/statistics/PassRateStatisticsServiceTest.java
+++ b/src/test/java/uk/gov/digital/ho/proving/income/audit/statistics/PassRateStatisticsServiceTest.java
@@ -1,0 +1,41 @@
+package uk.gov.digital.ho.proving.income.audit.statistics;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+import uk.gov.digital.ho.proving.income.audit.AuditClient;
+import uk.gov.digital.ho.proving.income.audit.AuditResultByNino;
+
+import java.time.LocalDate;
+import java.util.List;
+
+import static org.mockito.Mockito.verify;
+
+@RunWith(MockitoJUnitRunner.class)
+public class PassRateStatisticsServiceTest {
+
+    @Mock
+    private AuditClient mockAuditClient;
+    @Mock
+    private PassStatisticsCalculator mockPassStatisticsCalculator;
+
+    private PassRateStatisticsService service;
+
+    @Before
+    public void setUp() {
+        service = new PassRateStatisticsService(mockAuditClient, mockPassStatisticsCalculator);
+    }
+
+    @Test
+    public void generatePassRateStatistics_givenDates_callCollaborators() {
+        LocalDate fromDate = LocalDate.MIN;
+        LocalDate toDate = LocalDate.MAX;
+        List<AuditResultByNino> records;
+//        given some records returned
+
+        service.generatePassRateStatistics(fromDate, toDate);
+//        verify(mockPassStatisticsCalculator).result(records);
+    }
+}

--- a/src/test/java/uk/gov/digital/ho/proving/income/audit/statistics/PassRateStatisticsServiceTest.java
+++ b/src/test/java/uk/gov/digital/ho/proving/income/audit/statistics/PassRateStatisticsServiceTest.java
@@ -48,6 +48,10 @@ public class PassRateStatisticsServiceTest {
         service = new PassRateStatisticsService(mockAuditClient, mockPassStatisticsCalculator, mockConsolidator, PAGE_SIZE);
     }
 
+    /**************************
+     * AuditClient collaborator
+     **************************/
+
     @Test
     public void generatePassStatistics_givenPageSize_requestedPageSize() {
         int pageSize = 200;
@@ -81,7 +85,7 @@ public class PassRateStatisticsServiceTest {
     }
 
     @Test
-    public void generatePassStatistics_resultsFromAuditSerivce_requestAnotherPage() {
+    public void generatePassStatistics_resultsFromAuditService_requestAnotherPage() {
         AuditRecord someAuditRecord = new AuditRecord("some id", SOME_DATE_TIME, "some email", SOME_AUDIT_EVENT_TYPE, SOME_JSON, "some nino");
 
         when(mockAuditClient.getAuditHistoryPaginated(anyList(), eq(0), eq(PAGE_SIZE)))
@@ -93,6 +97,10 @@ public class PassRateStatisticsServiceTest {
         verify(mockAuditClient)
             .getAuditHistoryPaginated(anyList(), eq(1), eq(PAGE_SIZE));
     }
+
+    /***************************************
+     * AuditResultConsolidator collaborator
+     ***************************************/
 
     @Test
     public void generatePassStatistics_givenResultsFromAuditService_passedToConsolidator() {
@@ -115,6 +123,10 @@ public class PassRateStatisticsServiceTest {
         service.generatePassRateStatistics(SOME_DATE, SOME_DATE);
         verify(mockConsolidator).consolidatedAuditResultsByNino(byCorrelationId);
     }
+
+    /****************************************
+     * PassStatisticsCalculator collaborator
+     ****************************************/
 
     @Test
     public void generatePassStatistics_givenFromDate_passedToCalculator() {

--- a/src/test/java/uk/gov/digital/ho/proving/income/audit/statistics/PassRateStatisticsServiceTest.java
+++ b/src/test/java/uk/gov/digital/ho/proving/income/audit/statistics/PassRateStatisticsServiceTest.java
@@ -37,8 +37,8 @@ public class PassRateStatisticsServiceTest {
     private static final int PAGE_SIZE = 1;
 
     private static final long SOME_LONG = 3;
-    private static final LocalDate SOME_DATE = LocalDate.now();
-    private static final LocalDateTime SOME_DATE_TIME = LocalDateTime.now();
+    private static final LocalDate SOME_DATE = LocalDate.MAX;
+    private static final LocalDateTime SOME_DATE_TIME = LocalDateTime.MAX;
     private static final AuditEventType SOME_AUDIT_EVENT_TYPE = INCOME_PROVING_FINANCIAL_STATUS_REQUEST;
     private static final JsonNode SOME_JSON = null;
     private static final AuditResultType SOME_AUDIT_RESULT_TYPE = AuditResultType.PASS;
@@ -114,6 +114,22 @@ public class PassRateStatisticsServiceTest {
 
         service.generatePassRateStatistics(SOME_DATE, SOME_DATE);
         verify(mockConsolidator).consolidatedAuditResultsByNino(byCorrelationId);
+    }
+
+    @Test
+    public void generatePassStatistics_givenFromDate_passedToCalculator() {
+        LocalDate fromDate = LocalDate.now();
+        service.generatePassRateStatistics(fromDate, SOME_DATE);
+
+        verify(mockPassStatisticsCalculator).result(anyList(), eq(fromDate), any(LocalDate.class));
+    }
+
+    @Test
+    public void generatePassStatistics_givenToDate_passedToCalculator() {
+        LocalDate toDate = LocalDate.now();
+        service.generatePassRateStatistics(SOME_DATE, toDate);
+
+        verify(mockPassStatisticsCalculator).result(anyList(), any(LocalDate.class), eq(toDate));
     }
 
     @Test

--- a/src/test/java/uk/gov/digital/ho/proving/income/audit/statistics/PassStatisticsCalculatorTest.java
+++ b/src/test/java/uk/gov/digital/ho/proving/income/audit/statistics/PassStatisticsCalculatorTest.java
@@ -85,7 +85,7 @@ public class PassStatisticsCalculatorTest {
     }
 
     @Test
-    public void result_lastDay_counted() {
+    public void result_lastDay_notCounted() {
         assertThat(accumulator.result(singletonList(new AuditResultByNino("some nino", emptyList(), TO_DATE, NOTFOUND))))
             .isEqualTo(statisticsForCounts(0, 0, 1, 0));
     }


### PR DESCRIPTION
Added a service to coordinate the generation of pass rate statistics. It gets all audit data from the audit client then passes to the PassRateStatisticsCalculator to obtain the values. This can go straight into master without manual testing as the interface is unchanged.