### PR TITLE
EE-16064 Allow the audit client to retrieve all pages

### DIFF
--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -71,3 +71,4 @@ audit.history.endpoint=${pttg.audit.url}/history
 audit.archive.endpoint=${pttg.audit.url}/archive
 
 audit.history.passratestats.pagesize=100
+audit.archive.history.pagesize=100


### PR DESCRIPTION
Add a method to the audit client to retrieve the entire history, hiding the paging.