### PR TITLE
Ee 16064 archive audit error handling

### DIFF
--- a/src/main/java/uk/gov/digital/ho/proving/income/audit/ArchiveAuditResponse.java
+++ b/src/main/java/uk/gov/digital/ho/proving/income/audit/ArchiveAuditResponse.java
@@ -1,4 +1,0 @@
-package uk.gov.digital.ho.proving.income.audit;
-
-class ArchiveAuditResponse {
-}

--- a/src/main/java/uk/gov/digital/ho/proving/income/audit/AuditClient.java
+++ b/src/main/java/uk/gov/digital/ho/proving/income/audit/AuditClient.java
@@ -116,7 +116,7 @@ public class AuditClient {
 
     void archiveAudit(ArchiveAuditRequest request) {
         HttpEntity<ArchiveAuditRequest> entity = new HttpEntity<>(request, generateRestHeaders());
-        ResponseEntity<ArchiveAuditResponse> response = restTemplate.exchange(auditArchiveEndpoint, POST, entity, new ParameterizedTypeReference<ArchiveAuditResponse>() {});
+        restTemplate.exchange(auditArchiveEndpoint, POST, entity, new ParameterizedTypeReference<ArchiveAuditResponse>() {});
     }
 
     @Recover

--- a/src/main/java/uk/gov/digital/ho/proving/income/audit/AuditClient.java
+++ b/src/main/java/uk/gov/digital/ho/proving/income/audit/AuditClient.java
@@ -116,7 +116,11 @@ public class AuditClient {
 
     void archiveAudit(ArchiveAuditRequest request) {
         HttpEntity<ArchiveAuditRequest> entity = new HttpEntity<>(request, generateRestHeaders());
-        restTemplate.exchange(auditArchiveEndpoint, POST, entity, new ParameterizedTypeReference<ArchiveAuditResponse>() {});
+        try {
+            restTemplate.exchange(auditArchiveEndpoint, POST, entity, Void.class);
+        } catch(RestClientException ex) {
+            log.error(String.format("Archive audit request for %s returned error %s", request, ex));
+        }
     }
 
     @Recover


### PR DESCRIPTION
Tidy up the archive audit client as the API does not return a response body.
Add some error handling to the archive audit client.