### PR TITLE
Ee 16064 test in dev

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -64,7 +64,7 @@ pipeline:
       - cd kube-pttg-ip-api
       - ./deploy.sh
     when:
-      branch: [mast7]
+      branch: [master]
       event: [push, tag]
 
   deployment:

--- a/.drone.yml
+++ b/.drone.yml
@@ -14,7 +14,7 @@ pipeline:
     commands:
       - docker build -t pttg-ip-api .
     when:
-      branch: [master, refs/tags/*, EE-16064-test-in-dev]
+      branch: [master, refs/tags/*]
       event: [push, tag]
 
   install-docker-image:
@@ -28,7 +28,7 @@ pipeline:
       - docker tag pttg-ip-api quay.io/ukhomeofficedigital/pttg-ip-api:build-$${DRONE_BUILD_NUMBER}
       - docker push quay.io/ukhomeofficedigital/pttg-ip-api:build-$${DRONE_BUILD_NUMBER}
     when:
-      branch: [master, EE-16064-test-in-dev]
+      branch: [master]
       event: push
 
   tag-docker-image-with-git-tag:
@@ -64,7 +64,7 @@ pipeline:
       - cd kube-pttg-ip-api
       - ./deploy.sh
     when:
-      branch: [master, EE-16064-test-in-dev]
+      branch: [mast7]
       event: [push, tag]
 
   deployment:

--- a/.drone.yml
+++ b/.drone.yml
@@ -14,7 +14,7 @@ pipeline:
     commands:
       - docker build -t pttg-ip-api .
     when:
-      branch: [master, refs/tags/*, EE-8760-correlationId]
+      branch: [master, refs/tags/*, EE-16064-test-in-dev]
       event: [push, tag]
 
   install-docker-image:
@@ -28,7 +28,7 @@ pipeline:
       - docker tag pttg-ip-api quay.io/ukhomeofficedigital/pttg-ip-api:build-$${DRONE_BUILD_NUMBER}
       - docker push quay.io/ukhomeofficedigital/pttg-ip-api:build-$${DRONE_BUILD_NUMBER}
     when:
-      branch: [master, EE-8760-correlationId]
+      branch: [master, EE-16064-test-in-dev]
       event: push
 
   tag-docker-image-with-git-tag:
@@ -64,7 +64,7 @@ pipeline:
       - cd kube-pttg-ip-api
       - ./deploy.sh
     when:
-      branch: [master, EE-8760-correlationId]
+      branch: [master, EE-16064-test-in-dev]
       event: [push, tag]
 
   deployment:

--- a/src/main/java/uk/gov/digital/ho/proving/income/audit/ArchiveAuditRequest.java
+++ b/src/main/java/uk/gov/digital/ho/proving/income/audit/ArchiveAuditRequest.java
@@ -17,13 +17,11 @@ import java.util.List;
 @ToString
 class ArchiveAuditRequest {
     @JsonProperty
-    private String nino;
+    private String result;
     @JsonProperty
     private LocalDate lastArchiveDate;
     @JsonProperty
-    private List<String> eventIds;
+    private List<String> correlationIds;
     @JsonProperty
-    private String result;
-    @JsonProperty
-    private LocalDate resultDate;
+    private String nino;
 }

--- a/src/main/java/uk/gov/digital/ho/proving/income/audit/AuditArchiveService.java
+++ b/src/main/java/uk/gov/digital/ho/proving/income/audit/AuditArchiveService.java
@@ -37,7 +37,7 @@ class AuditArchiveService {
         List<AuditResultByNino> consolidatedByNino = auditResultConsolidator.consolidatedAuditResultsByNino(byCorrelationId);
 
         for (AuditResultByNino auditResult : consolidatedByNino) {
-            auditClient.archiveAudit(generateAuditHistoryRequest(auditResult, config));
+            auditClient.archiveAudit(generateAuditHistoryRequest(auditResult, config), auditResult.date());
         }
     }
 
@@ -48,10 +48,9 @@ class AuditArchiveService {
     private ArchiveAuditRequest generateAuditHistoryRequest(AuditResultByNino auditResult, AuditArchiveConfig config) {
         return ArchiveAuditRequest.builder()
             .nino(auditResult.nino())
-            .eventIds(auditResult.correlationIds())
+            .correlationIds(auditResult.correlationIds())
             .lastArchiveDate(config.lastArchiveDate())
             .result(auditResult.resultType().name())
-            .resultDate(auditResult.date())
             .build();
     }
 

--- a/src/main/java/uk/gov/digital/ho/proving/income/audit/AuditClient.java
+++ b/src/main/java/uk/gov/digital/ho/proving/income/audit/AuditClient.java
@@ -17,10 +17,12 @@ import org.springframework.web.client.RestTemplate;
 import org.springframework.web.util.UriComponentsBuilder;
 import uk.gov.digital.ho.proving.income.api.RequestData;
 
+import javax.swing.text.DateFormatter;
 import java.net.URI;
 import java.time.Clock;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
@@ -107,10 +109,11 @@ public class AuditClient {
         return response.getBody();
     }
 
-    void archiveAudit(ArchiveAuditRequest request) {
+    void archiveAudit(ArchiveAuditRequest request, LocalDate resultDate) {
         HttpEntity<ArchiveAuditRequest> entity = new HttpEntity<>(request, generateRestHeaders());
+        String date = DateTimeFormatter.ISO_DATE.format(resultDate);
         try {
-            restTemplate.exchange(auditArchiveEndpoint, POST, entity, Void.class);
+            restTemplate.exchange(auditArchiveEndpoint + "/" + date, POST, entity, Void.class);
         } catch(RestClientException ex) {
             log.error(String.format("Archive audit request for %s returned error %s", request, ex));
         }

--- a/src/main/java/uk/gov/digital/ho/proving/income/audit/AuditClient.java
+++ b/src/main/java/uk/gov/digital/ho/proving/income/audit/AuditClient.java
@@ -100,14 +100,7 @@ public class AuditClient {
     }
 
     private List<AuditRecord> getAuditHistoryPaginated(LocalDate toDate, List<AuditEventType> eventTypes, int page, int size) {
-    URI uri = UriComponentsBuilder.fromHttpUrl(auditHistoryEndpoint)
-        .queryParam("eventTypes", eventTypes)
-        .queryParam("page", page)
-        .queryParam("size", size)
-        .queryParam("toDate", toDate)
-        .build()
-        .encode()
-        .toUri();
+        URI uri = generateUri(toDate, eventTypes, page, size);
 
         HttpEntity<Void> entity = new HttpEntity<>(generateRestHeaders());
         ResponseEntity<List<AuditRecord>> response = restTemplate.exchange(uri, GET, entity, new ParameterizedTypeReference<List<AuditRecord>>() {});
@@ -121,6 +114,17 @@ public class AuditClient {
         } catch(RestClientException ex) {
             log.error(String.format("Archive audit request for %s returned error %s", request, ex));
         }
+    }
+
+    URI generateUri(LocalDate toDate, List<AuditEventType> eventTypes, int page, int size) {
+        return UriComponentsBuilder.fromHttpUrl(auditHistoryEndpoint)
+            .queryParam("eventTypes", eventTypes.toArray(new AuditEventType[0]))
+            .queryParam("page", page)
+            .queryParam("size", size)
+            .queryParam("toDate", toDate)
+            .build()
+            .encode()
+            .toUri();
     }
 
     @Recover

--- a/src/main/java/uk/gov/digital/ho/proving/income/audit/AuditResultComparator.java
+++ b/src/main/java/uk/gov/digital/ho/proving/income/audit/AuditResultComparator.java
@@ -17,7 +17,7 @@ class AuditResultComparator implements Comparator<AuditResult> {
     public int compare(AuditResult first, AuditResult second) {
         int result = auditResultTypeComparator.compare(first.resultType(), second.resultType());
         if (result == 0) {
-            result = first.date().compareTo(second.date());
+            result = second.date().compareTo(first.date());
         }
         return result;
     }

--- a/src/main/java/uk/gov/digital/ho/proving/income/audit/AuditResultConsolidator.java
+++ b/src/main/java/uk/gov/digital/ho/proving/income/audit/AuditResultConsolidator.java
@@ -43,12 +43,12 @@ public class AuditResultConsolidator {
             results.stream().collect(Collectors.groupingBy(AuditResult::nino));
 
         return resultsByNino.values().stream()
-            .map(this::consolidateLatestBestResult)
+            .map(this::consolidateFirstBestResult)
             .filter(Objects::nonNull)
             .collect(Collectors.toList());
     }
 
-    private AuditResultByNino consolidateLatestBestResult(List<AuditResult> results) {
+    private AuditResultByNino consolidateFirstBestResult(List<AuditResult> results) {
         AuditResult consolidatedResult = results.stream()
             .max(auditResultComparator)
             .orElse(null);

--- a/src/test/java/uk/gov/digital/ho/proving/income/audit/AuditArchiveServiceIT.java
+++ b/src/test/java/uk/gov/digital/ho/proving/income/audit/AuditArchiveServiceIT.java
@@ -131,7 +131,7 @@ public class AuditArchiveServiceIT {
     }
 
     @Test
-    public void archiveAudit_multipleMatchingResults_latestResultReturned() {
+    public void archiveAudit_multipleMatchingResults_firstResultReturned() {
         String earlyRequest = fileUtils.buildRequest("corr-id-1", "2019-01-01 12:00:00.000", "nino_1");
         String earlyResponse = fileUtils.buildResponse("corr-id-1", "2019-01-01 13:00:00.000", "nino_1", "true");
         String laterRequest = fileUtils.buildRequest("corr-id-2", "2019-01-02 14:00:00.000", "nino_1");
@@ -143,7 +143,7 @@ public class AuditArchiveServiceIT {
             .andRespond(withSuccess(auditHistory, APPLICATION_JSON));
 
         mockAuditService
-            .expect(requestTo(containsString("/archive/2019-01-02")))
+            .expect(requestTo(containsString("/archive/2019-01-01")))
             .andExpect(method(POST))
             .andExpect(jsonPath("$.nino", equalTo("nino_1")))
             .andRespond(withSuccess());
@@ -152,13 +152,13 @@ public class AuditArchiveServiceIT {
     }
 
     @Test
-    public void archiveAudit_multipleMatchingAndMultipleResults_latestResultForAllRequestsReturned() {
+    public void archiveAudit_multipleMatchingAndMultipleResults_firstResultForAllRequestsReturned() {
         // nino_1 has best result of FAIL
         String nino1RequestFail = fileUtils.buildRequest("corr-id-1", "2019-01-01 12:00:00.000", "nino_1");
         String nino1ResponseFail = fileUtils.buildResponse("corr-id-1", "2019-01-01 13:00:00.000", "nino_1", "false");
         String nino1RequestNoResponse = fileUtils.buildRequest("corr-id-3", "2019-01-02 14:00:00.000", "nino_1");
 
-        // nino_2 has best result of PASS, with the latest being on 2019-01-03
+        // nino_2 has best result of PASS, with the first being on 2019-01-02
         String nino2FirstPassRequest = fileUtils.buildRequest("corr-id-2", "2019-01-02 14:00:00.000", "nino_2");
         String nino2FirstPassResponse = fileUtils.buildResponse("corr-id-2", "2019-01-02 15:00:00.000", "nino_2", "true");
         String nino2SecondPassRequest = fileUtils.buildRequest("corr-id-5", "2019-01-03 14:00:00.000", "nino_2");
@@ -191,7 +191,7 @@ public class AuditArchiveServiceIT {
 
         // should have archived latest PASS for nino_2
         mockAuditService
-            .expect(requestTo(containsString("/archive/2019-01-03")))
+            .expect(requestTo(containsString("/archive/2019-01-02")))
             .andExpect(method(POST))
             .andExpect(jsonPath("$.nino", is("nino_2")))
             .andExpect(jsonPath("$.correlationIds.*", containsInAnyOrder("corr-id-2", "corr-id-5", "corr-id-6")))

--- a/src/test/java/uk/gov/digital/ho/proving/income/audit/AuditArchiveServiceIT.java
+++ b/src/test/java/uk/gov/digital/ho/proving/income/audit/AuditArchiveServiceIT.java
@@ -69,22 +69,20 @@ public class AuditArchiveServiceIT {
 
         String endOfArchive = LocalDate.now().minusMonths(6).minusDays(1).format(DateTimeFormatter.ISO_DATE);
         mockAuditService
-            .expect(requestTo(containsString("/archive")))
+            .expect(requestTo(containsString("/archive/2019-01-01")))
             .andExpect(method(POST))
             .andExpect(jsonPath("$.nino", is("nino_1")))
             .andExpect(jsonPath("$.lastArchiveDate", is(endOfArchive)))
-            .andExpect(jsonPath("$.eventIds.*", containsInAnyOrder("corr-id-1")))
+            .andExpect(jsonPath("$.correlationIds.*", containsInAnyOrder("corr-id-1")))
             .andExpect(jsonPath("$.result", is("PASS")))
-            .andExpect(jsonPath("$.resultDate", is("2019-01-01")))
             .andRespond(withSuccess());
         mockAuditService
-            .expect(requestTo(containsString("/archive")))
+            .expect(requestTo(containsString("/archive/2019-01-01")))
             .andExpect(method(POST))
             .andExpect(jsonPath("$.nino", is("nino_2")))
             .andExpect(jsonPath("$.lastArchiveDate", is(endOfArchive)))
-            .andExpect(jsonPath("$.eventIds.*", containsInAnyOrder("corr-id-2")))
+            .andExpect(jsonPath("$.correlationIds.*", containsInAnyOrder("corr-id-2")))
             .andExpect(jsonPath("$.result", is("PASS")))
-            .andExpect(jsonPath("$.resultDate", is("2019-01-01")))
             .andRespond(withSuccess());
 
         auditArchiveService.archiveAudit();
@@ -100,12 +98,11 @@ public class AuditArchiveServiceIT {
             .andRespond(withSuccess(auditHistory, APPLICATION_JSON));
 
         mockAuditService
-            .expect(requestTo(containsString("/archive")))
+            .expect(requestTo(containsString("/archive/2019-01-02")))
             .andExpect(method(POST))
             .andExpect(jsonPath("$.nino", is("nino_1")))
-            .andExpect(jsonPath("$.eventIds.*", containsInAnyOrder("corr-id-1")))
+            .andExpect(jsonPath("$.correlationIds.*", containsInAnyOrder("corr-id-1")))
             .andExpect(jsonPath("$.result", is("ERROR")))
-            .andExpect(jsonPath("$.resultDate", is("2019-01-02")))
             .andRespond(withSuccess());
 
         auditArchiveService.archiveAudit();
@@ -126,7 +123,7 @@ public class AuditArchiveServiceIT {
             .expect(requestTo(containsString("/archive")))
             .andExpect(method(POST))
             .andExpect(jsonPath("$.nino", is("nino_1")))
-            .andExpect(jsonPath("$.eventIds.*", containsInAnyOrder("corr-id-1", "corr-id-2")))
+            .andExpect(jsonPath("$.correlationIds.*", containsInAnyOrder("corr-id-1", "corr-id-2")))
             .andExpect(jsonPath("$.result", is("NOTFOUND")))
             .andRespond(withSuccess());
 
@@ -146,10 +143,9 @@ public class AuditArchiveServiceIT {
             .andRespond(withSuccess(auditHistory, APPLICATION_JSON));
 
         mockAuditService
-            .expect(requestTo(containsString("/archive")))
+            .expect(requestTo(containsString("/archive/2019-01-02")))
             .andExpect(method(POST))
             .andExpect(jsonPath("$.nino", equalTo("nino_1")))
-            .andExpect(jsonPath("$.resultDate", equalTo("2019-01-02")))
             .andRespond(withSuccess());
 
         auditArchiveService.archiveAudit();
@@ -186,32 +182,29 @@ public class AuditArchiveServiceIT {
 
         // should have archived best result for nino_1 - FAIL
         mockAuditService
-            .expect(requestTo(containsString("/archive")))
+            .expect(requestTo(containsString("/archive/2019-01-01")))
             .andExpect(method(POST))
             .andExpect(jsonPath("$.nino", is("nino_1")))
-            .andExpect(jsonPath("$.eventIds.*", containsInAnyOrder("corr-id-1", "corr-id-3")))
+            .andExpect(jsonPath("$.correlationIds.*", containsInAnyOrder("corr-id-1", "corr-id-3")))
             .andExpect(jsonPath("$.result", is("FAIL")))
-            .andExpect(jsonPath("$.resultDate", is("2019-01-01")))
             .andRespond(withSuccess());
 
         // should have archived latest PASS for nino_2
         mockAuditService
-            .expect(requestTo(containsString("/archive")))
+            .expect(requestTo(containsString("/archive/2019-01-03")))
             .andExpect(method(POST))
             .andExpect(jsonPath("$.nino", is("nino_2")))
-            .andExpect(jsonPath("$.eventIds.*", containsInAnyOrder("corr-id-2", "corr-id-5", "corr-id-6")))
+            .andExpect(jsonPath("$.correlationIds.*", containsInAnyOrder("corr-id-2", "corr-id-5", "corr-id-6")))
             .andExpect(jsonPath("$.result", is("PASS")))
-            .andExpect(jsonPath("$.resultDate", is("2019-01-03")))
             .andRespond(withSuccess());
 
         // should have archived best result for nino_3 - NOTFOUND
         mockAuditService
-            .expect(requestTo(containsString("/archive")))
+            .expect(requestTo(containsString("/archive/2019-01-03")))
             .andExpect(method(POST))
             .andExpect(jsonPath("$.nino", is("nino_3")))
-            .andExpect(jsonPath("$.eventIds.*", containsInAnyOrder("corr-id-7", "corr-id-8")))
+            .andExpect(jsonPath("$.correlationIds.*", containsInAnyOrder("corr-id-7", "corr-id-8")))
             .andExpect(jsonPath("$.result", is("NOTFOUND")))
-            .andExpect(jsonPath("$.resultDate", is("2019-01-03")))
             .andRespond(withSuccess());
 
         auditArchiveService.archiveAudit();
@@ -230,17 +223,15 @@ public class AuditArchiveServiceIT {
             .andRespond(withSuccess(auditHistory, APPLICATION_JSON));
 
         mockAuditService
-            .expect(requestTo(containsString("/archive")))
+            .expect(requestTo(containsString("/archive/2019-01-01")))
             .andExpect(method(POST))
             .andExpect(jsonPath("$.nino", equalTo("nino_1")))
-            .andExpect(jsonPath("$.resultDate", equalTo("2019-01-01")))
             .andRespond(withServerError());
 
         mockAuditService
-            .expect(requestTo(containsString("/archive")))
+            .expect(requestTo(containsString("/archive/2019-01-02")))
             .andExpect(method(POST))
             .andExpect(jsonPath("$.nino", equalTo("nino_2")))
-            .andExpect(jsonPath("$.resultDate", equalTo("2019-01-02")))
             .andRespond(withSuccess());
 
         auditArchiveService.archiveAudit();
@@ -259,17 +250,15 @@ public class AuditArchiveServiceIT {
             .andRespond(withSuccess(auditHistory, APPLICATION_JSON));
 
         mockAuditService
-            .expect(requestTo(containsString("/archive")))
+            .expect(requestTo(containsString("/archive/2019-01-01")))
             .andExpect(method(POST))
             .andExpect(jsonPath("$.nino", equalTo("nino_1")))
-            .andExpect(jsonPath("$.resultDate", equalTo("2019-01-01")))
             .andRespond(withBadRequest());
 
         mockAuditService
-            .expect(requestTo(containsString("/archive")))
+            .expect(requestTo(containsString("/archive/2019-01-02")))
             .andExpect(method(POST))
             .andExpect(jsonPath("$.nino", equalTo("nino_2")))
-            .andExpect(jsonPath("$.resultDate", equalTo("2019-01-02")))
             .andRespond(withSuccess());
 
         auditArchiveService.archiveAudit();

--- a/src/test/java/uk/gov/digital/ho/proving/income/audit/AuditArchiveServiceTest.java
+++ b/src/test/java/uk/gov/digital/ho/proving/income/audit/AuditArchiveServiceTest.java
@@ -48,7 +48,7 @@ public class AuditArchiveServiceTest {
         verify(mockAuditClient).getAuditHistory(auditEndDate, AUDIT_EVENTS_TO_ARCHIVE);
         verify(mockAuditResultConsolidator).auditResultsByCorrelationId(history);
         verify(mockAuditResultConsolidator).consolidatedAuditResultsByNino(resultsByCorrelationId);
-        verify(mockAuditClient).archiveAudit(any(ArchiveAuditRequest.class));
+        verify(mockAuditClient).archiveAudit(any(ArchiveAuditRequest.class), any(LocalDate.class));
     }
 
     private List<AuditResult> getAuditResultsByCorrelationId() {

--- a/src/test/java/uk/gov/digital/ho/proving/income/audit/AuditResultComparatorTest.java
+++ b/src/test/java/uk/gov/digital/ho/proving/income/audit/AuditResultComparatorTest.java
@@ -38,19 +38,19 @@ public class AuditResultComparatorTest {
     }
 
     @Test
-    public void compareTo_sameStatus_moreRecent_greater() {
+    public void compareTo_sameStatus_moreRecent_lesser() {
         AuditResult auditResult1 = new AuditResult("any_correlation_id", now().plusDays(1), "any_nino", FAIL);
         AuditResult auditResult2 = new AuditResult("any_correlation_id", now(), "any_nino", FAIL);
 
-        assertThat(auditResultComparator.compare(auditResult1, auditResult2)).isEqualTo(1);
+        assertThat(auditResultComparator.compare(auditResult1, auditResult2)).isEqualTo(-1);
     }
 
     @Test
-    public void compareTo_sameStatus_older_lesser() {
+    public void compareTo_sameStatus_older_greater() {
         AuditResult auditResult1 = new AuditResult("any_correlation_id", now(), "any_nino", FAIL);
         AuditResult auditResult2 = new AuditResult("any_correlation_id", now().plusDays(1), "any_nino", FAIL);
 
-        assertThat(auditResultComparator.compare(auditResult1, auditResult2)).isEqualTo(-1);
+        assertThat(auditResultComparator.compare(auditResult1, auditResult2)).isEqualTo(1);
     }
 
     @Test
@@ -62,8 +62,8 @@ public class AuditResultComparatorTest {
         List<AuditResult> results = Arrays.asList(auditResult1, auditResult2,  auditResult3);
         results.sort(auditResultComparator);
 
-        assertThat(results.get(0).correlationId()).isEqualTo("any_correlation_id_3");
-        assertThat(results.get(1).correlationId()).isEqualTo("any_correlation_id_2");
+        assertThat(results.get(0).correlationId()).isEqualTo("any_correlation_id_2");
+        assertThat(results.get(1).correlationId()).isEqualTo("any_correlation_id_3");
         assertThat(results.get(2).correlationId()).isEqualTo("any_correlation_id_1");
     }
 

--- a/src/test/java/uk/gov/digital/ho/proving/income/audit/AuditResultConsolidatorIT.java
+++ b/src/test/java/uk/gov/digital/ho/proving/income/audit/AuditResultConsolidatorIT.java
@@ -219,7 +219,7 @@ public class AuditResultConsolidatorIT {
     }
 
     @Test
-    public void byNino_multipleSameResults_mostRecentUsed() {
+    public void byNino_multipleSameResults_oldestUsed() {
         List<AuditResult> results =
             Arrays.asList(
                 new AuditResult("any_correlation_id", LocalDate.now(), "any_nino", PASS),
@@ -233,7 +233,7 @@ public class AuditResultConsolidatorIT {
             "any_correlation_id_3",
             "any_correlation_id_4"
         );
-        AuditResultByNino expected = new AuditResultByNino("any_nino", expectedCorrelationIds, LocalDate.now().plusDays(2), PASS);
+        AuditResultByNino expected = new AuditResultByNino("any_nino", expectedCorrelationIds, LocalDate.now(), PASS);
 
         List<AuditResultByNino> resultsByNino = auditResultConsolidator.consolidatedAuditResultsByNino(results);
 
@@ -270,7 +270,7 @@ public class AuditResultConsolidatorIT {
             );
         List<AuditResultByNino> expected = Arrays.asList(
                 new AuditResultByNino("any_nino", Arrays.asList("any_correlation_id_2", "any_correlation_id"), LocalDate.now(), PASS),
-                new AuditResultByNino("any_nino_2", Arrays.asList("any_correlation_id_3", "any_correlation_id_4"), LocalDate.now().plusDays(1), PASS)
+                new AuditResultByNino("any_nino_2", Arrays.asList("any_correlation_id_3", "any_correlation_id_4"), LocalDate.now(), PASS)
             );
 
         List<AuditResultByNino> resultsByNino = auditResultConsolidator.consolidatedAuditResultsByNino(results);


### PR DESCRIPTION
Following a test in dev, the following changes have been made:
- Fix the audit client to call the new format of the audit archive endpint (/archive/{date})
- Fix the URL for multiple event types when calling the audit history service
- Use the first best result instead of the last best result when archiving for a nino