### PR TITLE
Ee 16843 monthly and tax year stats

### DIFF
--- a/src/main/java/uk/gov/digital/ho/proving/income/api/FinancialStatusResource.java
+++ b/src/main/java/uk/gov/digital/ho/proving/income/api/FinancialStatusResource.java
@@ -1,9 +1,7 @@
 package uk.gov.digital.ho.proving.income.api;
 
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 import uk.gov.digital.ho.proving.income.api.domain.*;
 import uk.gov.digital.ho.proving.income.audit.AuditClient;
 import uk.gov.digital.ho.proving.income.hmrc.domain.IncomeRecord;

--- a/src/main/java/uk/gov/digital/ho/proving/income/api/FinancialStatusResource.java
+++ b/src/main/java/uk/gov/digital/ho/proving/income/api/FinancialStatusResource.java
@@ -1,7 +1,9 @@
 package uk.gov.digital.ho.proving.income.api;
 
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.web.bind.annotation.*;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RestController;
 import uk.gov.digital.ho.proving.income.api.domain.*;
 import uk.gov.digital.ho.proving.income.audit.AuditClient;
 import uk.gov.digital.ho.proving.income.hmrc.domain.IncomeRecord;

--- a/src/main/java/uk/gov/digital/ho/proving/income/api/domain/TaxYear.java
+++ b/src/main/java/uk/gov/digital/ho/proving/income/api/domain/TaxYear.java
@@ -1,0 +1,52 @@
+package uk.gov.digital.ho.proving.income.api.domain;
+
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.experimental.Accessors;
+
+import java.time.LocalDate;
+import java.time.Month;
+import java.time.Year;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+@AllArgsConstructor(access = AccessLevel.PACKAGE)
+@Getter
+@Accessors(fluent = true)
+public class TaxYear {
+
+    private static final Pattern TAX_YEAR_FORMAT_REGEX = Pattern.compile("(?<startYear>\\d{4})/(?<endYear>\\d{4})");
+
+    private final LocalDate startDate;
+    private final LocalDate endDate;
+
+    public static TaxYear valueOf(String taxYear) {
+        Year[] years = validate(taxYear);
+
+        return new TaxYear(
+            years[0].atMonth(Month.APRIL).atDay(6),
+            years[1].atMonth(Month.APRIL).atDay(5)
+        );
+    }
+
+    private static Year[] validate(String taxYear) {
+        if (taxYear == null) {
+            throw new IllegalArgumentException("Can't create taxYear from null");
+        }
+
+        Matcher matcher = TAX_YEAR_FORMAT_REGEX.matcher(taxYear);
+        if (!matcher.matches()) {
+            throw new IllegalArgumentException("TaxYear must be in format YYYY/YYYY");
+        }
+
+        int startYear = Integer.valueOf(matcher.group("startYear"));
+        int endYear = Integer.valueOf(matcher.group("endYear"));
+
+        if (endYear - startYear != 1) {
+            throw new IllegalArgumentException("Years must be consecutive");
+        }
+
+        return new Year[]{Year.of(startYear), Year.of(endYear)};
+    }
+}

--- a/src/main/java/uk/gov/digital/ho/proving/income/audit/statistics/PassRateStatisticsService.java
+++ b/src/main/java/uk/gov/digital/ho/proving/income/audit/statistics/PassRateStatisticsService.java
@@ -2,6 +2,7 @@ package uk.gov.digital.ho.proving.income.audit.statistics;
 
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
+import uk.gov.digital.ho.proving.income.api.domain.TaxYear;
 import uk.gov.digital.ho.proving.income.audit.*;
 
 import java.time.LocalDate;
@@ -38,6 +39,10 @@ public class PassRateStatisticsService {
 
     public PassRateStatistics generatePassRateStatistics(YearMonth calendarMonth) {
         return generatePassRateStatistics(calendarMonth.atDay(1), calendarMonth.atEndOfMonth());
+    }
+
+    public PassRateStatistics generatePassRateStatistics(TaxYear taxYear) {
+        return generatePassRateStatistics(taxYear.startDate(), taxYear.endDate());
     }
 
     public PassRateStatistics generatePassRateStatistics(LocalDate fromDate, LocalDate toDate) {

--- a/src/main/java/uk/gov/digital/ho/proving/income/audit/statistics/PassRateStatisticsService.java
+++ b/src/main/java/uk/gov/digital/ho/proving/income/audit/statistics/PassRateStatisticsService.java
@@ -5,6 +5,7 @@ import org.springframework.stereotype.Component;
 import uk.gov.digital.ho.proving.income.audit.*;
 
 import java.time.LocalDate;
+import java.time.YearMonth;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -33,6 +34,10 @@ public class PassRateStatisticsService {
         this.calculator = calculator;
         this.consolidator = consolidator;
         this.requestPageSize = requestPageSize;
+    }
+
+    public PassRateStatistics generatePassRateStatistics(YearMonth calendarMonth) {
+        return generatePassRateStatistics(calendarMonth.atDay(1), calendarMonth.atEndOfMonth());
     }
 
     public PassRateStatistics generatePassRateStatistics(LocalDate fromDate, LocalDate toDate) {

--- a/src/test/java/uk/gov/digital/ho/proving/income/api/domain/TaxYearTest.java
+++ b/src/test/java/uk/gov/digital/ho/proving/income/api/domain/TaxYearTest.java
@@ -1,0 +1,106 @@
+package uk.gov.digital.ho.proving.income.api.domain;
+
+import org.junit.Test;
+
+import java.time.LocalDate;
+import java.time.Month;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+public class TaxYearTest {
+
+    @Test
+    public void valueOf_givenStartYear_startDateIsSixthOfApril() {
+        TaxYear taxYear = TaxYear.valueOf("2018/2019");
+        assertThat(taxYear.startDate()).isEqualTo(LocalDate.of(2018, Month.APRIL, 6));
+    }
+
+    @Test
+    public void valueOf_givenEndYear_startDateIsFifthOfApril() {
+        TaxYear taxYear = TaxYear.valueOf("2018/2019");
+        assertThat(taxYear.endDate()).isEqualTo(LocalDate.of(2019, Month.APRIL, 5));
+    }
+
+    @Test
+    public void valueOf_threeCharStartYear_illegalArgumentException() {
+        assertThatThrownBy(() -> TaxYear.valueOf("998/0999"))
+            .isInstanceOf(IllegalArgumentException.class)
+            .hasMessageContaining("format");
+    }
+
+    @Test
+    public void valueOf_threeCharEndYear_illegalArgumentException() {
+        assertThatThrownBy(() -> TaxYear.valueOf("0998/999"))
+            .isInstanceOf(IllegalArgumentException.class)
+            .hasMessageContaining("format");
+    }
+
+    @Test
+    public void valueOf_fiveCharStartYear_illegalArgumentException() {
+        assertThatThrownBy(() -> TaxYear.valueOf("01998/1999"))
+            .isInstanceOf(IllegalArgumentException.class);
+    }
+
+    @Test
+    public void valueOf_fiveCharEndYear_illegalArgumentException() {
+        assertThatThrownBy(() -> TaxYear.valueOf("1998/01999"))
+            .isInstanceOf(IllegalArgumentException.class);
+    }
+
+    @Test
+    public void valueOf_noSlash_illegalArgumentException() {
+        assertThatThrownBy(() -> TaxYear.valueOf("19981999"))
+            .isInstanceOf(IllegalArgumentException.class)
+            .hasMessageContaining("format");
+    }
+
+    @Test
+    public void valueOf_twoSlashes_illegalArgumentException() {
+        assertThatThrownBy(() -> TaxYear.valueOf("1998//1999"))
+            .isInstanceOf(IllegalArgumentException.class)
+            .hasMessageContaining("format");
+    }
+
+    @Test
+    public void valueOf_threeYears_illegalArgumentException() {
+        assertThatThrownBy(() -> TaxYear.valueOf("1998/1999/2000"))
+            .isInstanceOf(IllegalArgumentException.class)
+            .hasMessageContaining("format");
+    }
+
+    @Test
+    public void valueOf_emptyString_illegalArgumentException() {
+        assertThatThrownBy(() -> TaxYear.valueOf(""))
+            .isInstanceOf(IllegalArgumentException.class)
+            .hasMessageContaining("format");
+    }
+
+    @Test
+    public void valueOf_null_illegalArgumentException() {
+        assertThatThrownBy(() -> TaxYear.valueOf(null))
+            .isInstanceOf(IllegalArgumentException.class)
+            .hasMessageContaining("from null");
+    }
+
+    @Test
+    public void valueOf_nonConsecutiveYears_illegalArgumentException() {
+        assertThatThrownBy(() -> TaxYear.valueOf("2014/2016"))
+            .isInstanceOf(IllegalArgumentException.class)
+            .hasMessageContaining("consecutive");
+    }
+
+    @Test
+    public void valueOf_nonNumericalEndYear_illegalArgumentException() {
+        assertThatThrownBy(() -> TaxYear.valueOf("2014/201A"))
+            .isInstanceOf(IllegalArgumentException.class)
+            .hasMessageContaining("format");
+    }
+
+    @Test
+    public void valueOf_nonNumericalStartYear_illegalArgumentException() {
+        assertThatThrownBy(() -> TaxYear.valueOf("2A14/2015"))
+            .isInstanceOf(IllegalArgumentException.class)
+            .hasMessageContaining("format");
+    }
+}

--- a/src/test/java/uk/gov/digital/ho/proving/income/api/domain/TaxYearTest.java
+++ b/src/test/java/uk/gov/digital/ho/proving/income/api/domain/TaxYearTest.java
@@ -91,6 +91,13 @@ public class TaxYearTest {
     }
 
     @Test
+    public void valueOf_consecutiveYearsLatestFirst_illegalArgumentException() {
+        assertThatThrownBy(() -> TaxYear.valueOf("2014/2013"))
+            .isInstanceOf(IllegalArgumentException.class)
+            .hasMessageContaining("consecutive");
+    }
+
+    @Test
     public void valueOf_nonNumericalEndYear_illegalArgumentException() {
         assertThatThrownBy(() -> TaxYear.valueOf("2014/201A"))
             .isInstanceOf(IllegalArgumentException.class)

--- a/src/test/java/uk/gov/digital/ho/proving/income/audit/statistics/PassRateStatisticsServiceCalendarMonthTest.java
+++ b/src/test/java/uk/gov/digital/ho/proving/income/audit/statistics/PassRateStatisticsServiceCalendarMonthTest.java
@@ -1,0 +1,79 @@
+package uk.gov.digital.ho.proving.income.audit.statistics;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+import uk.gov.digital.ho.proving.income.audit.AuditClient;
+import uk.gov.digital.ho.proving.income.audit.AuditEventType;
+import uk.gov.digital.ho.proving.income.audit.AuditRecord;
+import uk.gov.digital.ho.proving.income.audit.AuditResultConsolidator;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.Month;
+import java.time.YearMonth;
+import java.util.Collections;
+import java.util.List;
+
+import static java.util.Arrays.asList;
+import static java.util.Collections.singletonList;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static uk.gov.digital.ho.proving.income.audit.AuditEventType.INCOME_PROVING_FINANCIAL_STATUS_REQUEST;
+import static uk.gov.digital.ho.proving.income.audit.AuditEventType.INCOME_PROVING_FINANCIAL_STATUS_RESPONSE;
+
+@RunWith(MockitoJUnitRunner.class)
+public class PassRateStatisticsServiceCalendarMonthTest {
+
+    @Mock
+    private AuditClient mockAuditClient;
+    @Mock
+    private AuditResultConsolidator mockConsolidator;
+    @Mock
+    private PassStatisticsCalculator mockPassStatisticsCalculator;
+
+    private PassRateStatisticsService service;
+
+    private static final int PAGE_SIZE = 2;
+
+    @Before
+    public void setUp() {
+        service = new PassRateStatisticsService(mockAuditClient, mockPassStatisticsCalculator, mockConsolidator, PAGE_SIZE);
+    }
+
+    @Test
+    public void generatePassStatistics_thirtyOneDayMonth_fromFirstToThirtyFirst() {
+        YearMonth yearMonth = YearMonth.of(2018, Month.AUGUST);
+        service.generatePassRateStatistics(yearMonth);
+
+        verify(mockPassStatisticsCalculator).result(anyList(), anyList(), eq(LocalDate.of(2018, Month.AUGUST, 1)), eq(LocalDate.of(2018, Month.AUGUST, 31)));
+    }
+
+    @Test
+    public void generatePassStatistics_thirtyDayMonth_fromFirstToThirtieth() {
+        YearMonth yearMonth = YearMonth.of(2018, Month.SEPTEMBER);
+        service.generatePassRateStatistics(yearMonth);
+
+        verify(mockPassStatisticsCalculator).result(anyList(), anyList(), eq(LocalDate.of(2018, Month.SEPTEMBER, 1)), eq(LocalDate.of(2018, Month.SEPTEMBER, 30)));
+    }
+
+    @Test
+    public void generatePassStatistics_februaryNonLeapYear_fromFirstToTwentyEighth() {
+        YearMonth yearMonth = YearMonth.of(2018, Month.FEBRUARY);
+        service.generatePassRateStatistics(yearMonth);
+
+        verify(mockPassStatisticsCalculator).result(anyList(), anyList(), eq(LocalDate.of(2018, Month.FEBRUARY, 1)), eq(LocalDate.of(2018, Month.FEBRUARY, 28)));
+    }
+
+    @Test
+    public void generatePassStatistics_februaryLeapYear_fromFirstToTwentyEighth() {
+        YearMonth yearMonth = YearMonth.of(2016, Month.FEBRUARY);
+        service.generatePassRateStatistics(yearMonth);
+
+        verify(mockPassStatisticsCalculator).result(anyList(), anyList(), eq(LocalDate.of(2016, Month.FEBRUARY, 1)), eq(LocalDate.of(2016, Month.FEBRUARY, 29)));
+    }
+}

--- a/src/test/java/uk/gov/digital/ho/proving/income/audit/statistics/PassRateStatisticsServiceCalendarMonthTest.java
+++ b/src/test/java/uk/gov/digital/ho/proving/income/audit/statistics/PassRateStatisticsServiceCalendarMonthTest.java
@@ -1,30 +1,20 @@
 package uk.gov.digital.ho.proving.income.audit.statistics;
 
-import com.fasterxml.jackson.databind.JsonNode;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnitRunner;
 import uk.gov.digital.ho.proving.income.audit.AuditClient;
-import uk.gov.digital.ho.proving.income.audit.AuditEventType;
-import uk.gov.digital.ho.proving.income.audit.AuditRecord;
 import uk.gov.digital.ho.proving.income.audit.AuditResultConsolidator;
 
 import java.time.LocalDate;
-import java.time.LocalDateTime;
 import java.time.Month;
 import java.time.YearMonth;
-import java.util.Collections;
-import java.util.List;
 
-import static java.util.Arrays.asList;
-import static java.util.Collections.singletonList;
-import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.ArgumentMatchers.anyList;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
-import static uk.gov.digital.ho.proving.income.audit.AuditEventType.INCOME_PROVING_FINANCIAL_STATUS_REQUEST;
-import static uk.gov.digital.ho.proving.income.audit.AuditEventType.INCOME_PROVING_FINANCIAL_STATUS_RESPONSE;
 
 @RunWith(MockitoJUnitRunner.class)
 public class PassRateStatisticsServiceCalendarMonthTest {

--- a/src/test/java/uk/gov/digital/ho/proving/income/audit/statistics/PassRateStatisticsServiceTest.java
+++ b/src/test/java/uk/gov/digital/ho/proving/income/audit/statistics/PassRateStatisticsServiceTest.java
@@ -6,6 +6,7 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnitRunner;
+import uk.gov.digital.ho.proving.income.api.domain.TaxYear;
 import uk.gov.digital.ho.proving.income.audit.*;
 
 import java.time.LocalDate;
@@ -199,5 +200,14 @@ public class PassRateStatisticsServiceTest {
 
         PassRateStatistics actualStatistics = service.generatePassRateStatistics(SOME_DATE, SOME_DATE);
         assertThat(actualStatistics).isEqualTo(passRateStatistics);
+    }
+
+    @Test
+    public void generatePassStatistics_taxYear_datesPassedToCalculator() {
+        TaxYear taxYear = TaxYear.valueOf("2017/2018");
+        service.generatePassRateStatistics(taxYear);
+
+        verify(mockPassStatisticsCalculator)
+            .result(anyList(), anyList(), eq(taxYear.startDate()), eq(taxYear.endDate()));
     }
 }


### PR DESCRIPTION
Adding new versions of generatePassRateStatistics which takes a TaxYear or a YearMonth as a parameter. Can be merged straight to master as it is still not wired up