### PR TITLE
Ee 19133 add new endpoints audit client

### DIFF
--- a/src/main/java/uk/gov/digital/ho/proving/income/audit/AuditClient.java
+++ b/src/main/java/uk/gov/digital/ho/proving/income/audit/AuditClient.java
@@ -59,8 +59,8 @@ public class AuditClient {
         this.requestData = requestData;
         this.auditEndpoint = endpointProperties.getAuditEndpoint();
         this.auditHistoryEndpoint = endpointProperties.getHistoryEndpoint();
-        this.correlationIdsEndpoint = correlationIdsEndpoint;
-        this.historyByCorrelationIdEndpoint = historyByCorrelationIdEndpoint;
+        this.correlationIdsEndpoint = endpointProperties.getCorrelationIdsEndpoint();
+        this.historyByCorrelationIdEndpoint = endpointProperties.getHistoryByCorrelationIdEndpoint();
         this.auditArchiveEndpoint = endpointProperties.getArchiveEndpoint();
         this.historyPageSize = endpointProperties.getArchiveHistoryPageSize();
         this.mapper = mapper;

--- a/src/main/java/uk/gov/digital/ho/proving/income/audit/AuditClient.java
+++ b/src/main/java/uk/gov/digital/ho/proving/income/audit/AuditClient.java
@@ -53,7 +53,7 @@ public class AuditClient {
                 RequestData requestData,
                 @Value("${pttg.audit.endpoint}") String auditEndpoint,
                 @Value("${audit.history.endpoint}") String auditHistoryEndpoint,
-                @Value("${audit.history.correlationids.endpoint") String correlationIdsEndpoint,
+                @Value("${audit.history.correlationids.endpoint}") String correlationIdsEndpoint,
                 @Value("${audit.archive.endpoint}") String auditArchiveEndpoint,
                 @Value("${audit.archive.history.pagesize}") int historyPagesize,
                 ObjectMapper mapper) {

--- a/src/main/java/uk/gov/digital/ho/proving/income/audit/statistics/AuditClientEndpointProperties.java
+++ b/src/main/java/uk/gov/digital/ho/proving/income/audit/statistics/AuditClientEndpointProperties.java
@@ -17,6 +17,8 @@ public class AuditClientEndpointProperties {
     private String auditEndpoint;
     private String historyEndpoint;
     private String archiveEndpoint;
+    private String correlationIdsEndpoint;
+    private String historyByCorrelationIdEndpoint;
     private int archiveHistoryPageSize;
 }
 

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -69,6 +69,7 @@ auditing.deployment.namespace=local
 audit.history.months=6
 audit.history.endpoint=${pttg.audit.url}/history
 audit.history.correlationids.endpoint=${pttg.audit.url}/correlationIds
+audit.history.bycorrelationid.endpoint=${pttg.audit.url}/historyByCorrelationId
 audit.archive.endpoint=${pttg.audit.url}/archive
 
 audit.history.passratestats.pagesize=100

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -60,7 +60,7 @@ pttg.audit.audit-endpoint=${pttg.audit.url}/audit
 pttg.audit.history-endpoint=${pttg.audit.url}/history
 pttg.audit.archive-endpoint=${pttg.audit.url}/archive
 pttg.audit.correlation-ids-endpoint=${pttg.audit.url}/correlationIds
-pttg.audit.history-byc-orrelation-id-endpoint=${pttg.audit.url}/historyByCorrelationId
+pttg.audit.history-by-correlation-id-endpoint=${pttg.audit.url}/historyByCorrelationId
 
 pttg.audit.archive-history-page-size=100
 

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -68,6 +68,7 @@ auditing.deployment.namespace=local
 
 audit.history.months=6
 audit.history.endpoint=${pttg.audit.url}/history
+audit.history.correlationids.endpoint=${pttg.audit.url}/correlationIds
 audit.archive.endpoint=${pttg.audit.url}/archive
 
 audit.history.passratestats.pagesize=100

--- a/src/test/java/uk/gov/digital/ho/proving/income/audit/AuditClientTest.java
+++ b/src/test/java/uk/gov/digital/ho/proving/income/audit/AuditClientTest.java
@@ -521,9 +521,7 @@ public class AuditClientTest {
 
     @Test
     public void getHistoryByCorrelationId_anyRequest_expectedUriCalled() {
-        List<AuditRecord> anyAuditRecords = singletonList(new AuditRecord("some id", LocalDateTime.now(), "some email", INCOME_PROVING_FINANCIAL_STATUS_REQUEST, null, "some nino"));
-        when(mockRestTemplate.exchange(captorUri.capture(), eq(GET), any(HttpEntity.class), eq(new ParameterizedTypeReference<List<AuditRecord>>() {})))
-            .thenReturn(ResponseEntity.ok(anyAuditRecords));
+        stubGetHistoryForCorrelationId();
 
         List<AuditEventType> anyEventTypes = asList(INCOME_PROVING_FINANCIAL_STATUS_REQUEST, INCOME_PROVING_FINANCIAL_STATUS_RESPONSE);
         auditClient.getHistoryByCorrelationId("any correlation id", anyEventTypes);
@@ -534,9 +532,7 @@ public class AuditClientTest {
 
     @Test
     public void getHistoryByCorrelationId_givenParameters_expectedQueryString() {
-        List<AuditRecord> anyAuditRecords = singletonList(new AuditRecord("some id", LocalDateTime.now(), "some email", INCOME_PROVING_FINANCIAL_STATUS_REQUEST, null, "some nino"));
-        when(mockRestTemplate.exchange(captorUri.capture(), eq(GET), any(HttpEntity.class), eq(new ParameterizedTypeReference<List<AuditRecord>>() {})))
-            .thenReturn(ResponseEntity.ok(anyAuditRecords));
+        stubGetHistoryForCorrelationId();
 
         List<AuditEventType> someEventTypes = asList(INCOME_PROVING_FINANCIAL_STATUS_REQUEST, INCOME_PROVING_FINANCIAL_STATUS_RESPONSE);
         String someCorrelationId = "some-correlation-id";
@@ -551,12 +547,9 @@ public class AuditClientTest {
     @Test
     public void getHistoryByCorrelationId_anyRequest_shouldSetHeaders() {
         stubRequestData();
+        stubGetHistoryForCorrelationId();
+
         List<AuditEventType> anyEventTypes = asList(INCOME_PROVING_FINANCIAL_STATUS_REQUEST, INCOME_PROVING_FINANCIAL_STATUS_RESPONSE);
-        List<AuditRecord> anyAuditRecords = singletonList(new AuditRecord("some id", LocalDateTime.now(), "some email", INCOME_PROVING_FINANCIAL_STATUS_REQUEST, null, "some nino"));
-
-        when(mockRestTemplate.exchange(captorUri.capture(), eq(GET), any(HttpEntity.class), eq(new ParameterizedTypeReference<List<AuditRecord>>() {})))
-            .thenReturn(ResponseEntity.ok(anyAuditRecords));
-
         auditClient.getHistoryByCorrelationId("any correlation ID", anyEventTypes);
 
         verify(mockRestTemplate).exchange(any(URI.class), eq(GET), captorHttpEntity.capture(), eq(new ParameterizedTypeReference<List<AuditRecord>>() {}));
@@ -565,12 +558,13 @@ public class AuditClientTest {
         assertHeaders(headers);
     }
 
-
     @Test
     public void getHistoryByCorrelationId_givenResponse_returnAuditRecords() {
         List<AuditEventType> anyEventTypes = asList(INCOME_PROVING_FINANCIAL_STATUS_REQUEST, INCOME_PROVING_FINANCIAL_STATUS_RESPONSE);
 
-        List<AuditRecord> expectedAuditRecords = singletonList(new AuditRecord("some id", LocalDateTime.now(), "some email", INCOME_PROVING_FINANCIAL_STATUS_REQUEST, null, "some nino"));
+        AuditRecord someAuditRecord = new AuditRecord("some id", LocalDateTime.now(), "some email", INCOME_PROVING_FINANCIAL_STATUS_REQUEST, null, "some nino");
+        List<AuditRecord> expectedAuditRecords = singletonList(someAuditRecord);
+        
         when(mockRestTemplate.exchange(captorUri.capture(), eq(GET), any(HttpEntity.class), eq(new ParameterizedTypeReference<List<AuditRecord>>() {})))
             .thenReturn(ResponseEntity.ok(expectedAuditRecords));
 
@@ -598,6 +592,12 @@ public class AuditClientTest {
     private void stubGetAllCorrelationIds(List<String> correlationIds) {
         when(mockRestTemplate.exchange(captorUri.capture(), eq(GET), any(HttpEntity.class), eq(new ParameterizedTypeReference<List<String>>() {})))
             .thenReturn(ResponseEntity.ok(correlationIds));
+    }
+
+    private void stubGetHistoryForCorrelationId() {
+        AuditRecord anyAuditRecord = new AuditRecord("some id", LocalDateTime.now(), "some email", INCOME_PROVING_FINANCIAL_STATUS_REQUEST, null, "some nino");
+        when(mockRestTemplate.exchange(captorUri.capture(), eq(GET), any(HttpEntity.class), eq(new ParameterizedTypeReference<List<AuditRecord>>() {})))
+            .thenReturn(ResponseEntity.ok(singletonList(anyAuditRecord)));
     }
 
     private List<AuditRecord> getAuditRecords(int quantity) throws IOException {

--- a/src/test/java/uk/gov/digital/ho/proving/income/audit/AuditClientTest.java
+++ b/src/test/java/uk/gov/digital/ho/proving/income/audit/AuditClientTest.java
@@ -563,10 +563,9 @@ public class AuditClientTest {
         List<AuditEventType> anyEventTypes = asList(INCOME_PROVING_FINANCIAL_STATUS_REQUEST, INCOME_PROVING_FINANCIAL_STATUS_RESPONSE);
 
         AuditRecord someAuditRecord = new AuditRecord("some id", LocalDateTime.now(), "some email", INCOME_PROVING_FINANCIAL_STATUS_REQUEST, null, "some nino");
+        stubGetHistoryForCorrelationId(someAuditRecord);
+
         List<AuditRecord> expectedAuditRecords = singletonList(someAuditRecord);
-        
-        when(mockRestTemplate.exchange(captorUri.capture(), eq(GET), any(HttpEntity.class), eq(new ParameterizedTypeReference<List<AuditRecord>>() {})))
-            .thenReturn(ResponseEntity.ok(expectedAuditRecords));
 
         List<AuditRecord> actualAuditRecords = auditClient.getHistoryByCorrelationId("any correlation ID", anyEventTypes);
         assertThat(actualAuditRecords).isEqualTo(expectedAuditRecords);
@@ -596,6 +595,10 @@ public class AuditClientTest {
 
     private void stubGetHistoryForCorrelationId() {
         AuditRecord anyAuditRecord = new AuditRecord("some id", LocalDateTime.now(), "some email", INCOME_PROVING_FINANCIAL_STATUS_REQUEST, null, "some nino");
+        stubGetHistoryForCorrelationId(anyAuditRecord);
+    }
+
+    private void stubGetHistoryForCorrelationId(AuditRecord anyAuditRecord) {
         when(mockRestTemplate.exchange(captorUri.capture(), eq(GET), any(HttpEntity.class), eq(new ParameterizedTypeReference<List<AuditRecord>>() {})))
             .thenReturn(ResponseEntity.ok(singletonList(anyAuditRecord)));
     }

--- a/src/test/java/uk/gov/digital/ho/proving/income/audit/AuditClientTest.java
+++ b/src/test/java/uk/gov/digital/ho/proving/income/audit/AuditClientTest.java
@@ -96,6 +96,8 @@ public class AuditClientTest {
         endpointProperties.setHistoryEndpoint(SOME_HISTORY_ENDPOINT);
         endpointProperties.setArchiveEndpoint(SOME_ARCHIVE_ENDPOINT);
         endpointProperties.setArchiveHistoryPageSize(HISTORY_PAGE_SIZE);
+        endpointProperties.setCorrelationIdsEndpoint(SOME_CORRELATION_IDS_ENDPOINT);
+        endpointProperties.setHistoryByCorrelationIdEndpoint(SOME_HISTORY_BY_CORRELATION_ID_ENDPOINT);
 
         auditClient = new AuditClient(Clock.fixed(Instant.parse("2017-08-29T08:00:00Z"), ZoneId.of("UTC")),
             mockRestTemplate,

--- a/src/test/java/uk/gov/digital/ho/proving/income/audit/statistics/AuditClientEndpointPropertiesTest.java
+++ b/src/test/java/uk/gov/digital/ho/proving/income/audit/statistics/AuditClientEndpointPropertiesTest.java
@@ -18,6 +18,8 @@ import static org.assertj.core.api.Assertions.assertThat;
     "pttg.audit.audit-endpoint=${pttg.audit.url}/audit",
     "pttg.audit.history-endpoint=${pttg.audit.url}/history",
     "pttg.audit.archive-endpoint=${pttg.audit.url}/archive",
+    "pttg.audit.correlation-ids-endpoint=${pttg.audit.url}/correlationIds",
+    "pttg.audit.history-by-correlation-id-endpoint=${pttg.audit.url}/historyByCorrelationId",
     "pttg.audit.archive-history-page-size=1000"
 })
 public class AuditClientEndpointPropertiesTest {
@@ -34,6 +36,8 @@ public class AuditClientEndpointPropertiesTest {
         assertThat(auditClientEndpointProperties.getAuditEndpoint()).isEqualTo("http://somehost:8000/audit");
         assertThat(auditClientEndpointProperties.getHistoryEndpoint()).isEqualTo("http://somehost:8000/history");
         assertThat(auditClientEndpointProperties.getArchiveEndpoint()).isEqualTo("http://somehost:8000/archive");
+        assertThat(auditClientEndpointProperties.getCorrelationIdsEndpoint()).isEqualTo("http://somehost:8000/correlationIds");
+        assertThat(auditClientEndpointProperties.getHistoryByCorrelationIdEndpoint()).isEqualTo("http://somehost:8000/historyByCorrelationId");
         assertThat(auditClientEndpointProperties.getArchiveHistoryPageSize()).isEqualTo(1000);
     }
 }


### PR DESCRIPTION
Adding methods to access the two new routes in the audit-service, /correlationIds and /historyByCorrelationId. 

As these methods aren't yet used I intend to merge into master once approved.