### PR TITLE
Ee 19133 add checkstyle and address the issues

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -51,6 +51,7 @@ apply plugin: 'org.springframework.boot'
 apply plugin: 'io.spring.dependency-management'
 apply plugin: 'org.asciidoctor.convert'
 apply plugin: 'project-report'
+apply plugin: 'checkstyle'
 
 group 'pttg-ip-api'
 version = '0.1.0'
@@ -239,4 +240,10 @@ task('buildWithApiDocs', type: Jar, dependsOn: ['generateApiDocs', 'build']) {
 task buildSpringBootWithApiDocs(type: BootRepackage, dependsOn: buildWithApiDocs) {
     group 'build'
     description 'Builds the jar as a Spring Boot executable jar containing the api docs'
+}
+
+checkstyleTest.enabled = false
+checkstyle {
+    toolVersion = "5.9"
+    ignoreFailures = false
 }

--- a/config/checkstyle/checkstyle.xml
+++ b/config/checkstyle/checkstyle.xml
@@ -1,0 +1,118 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE module PUBLIC "-//Puppy Crawl//DTD Check Configuration 1.3//EN"
+        "http://www.puppycrawl.com/dtds/configuration_1_3.dtd">
+<!--
+    Checkstyle-Configuration: Clean Code Checks
+    Description: none
+        -->
+<module name="Checker">
+    <property name="severity" value="error"/>
+    <module name="TreeWalker">
+        <module name="IllegalImport">
+            <property name="illegalPkgs" value="sun,com.oracle,edu.emory.mathcs.backport.java.util"/>
+        </module>
+        <module name="ArrayTypeStyle"/>
+        <module name="AnonInnerLength">
+            <property name="max" value="50"/>
+        </module>
+        <module name="DefaultComesLast"/>
+        <module name="ModifierOrder"/>
+        <module name="OuterTypeNumber"/>
+        <module name="OuterTypeFilename"/>
+        <module name="CovariantEquals"/>
+        <module name="EqualsHashCode"/>
+        <module name="OneStatementPerLine"/>
+        <module name="StringLiteralEquality"/>
+        <module name="FallThrough"/>
+        <module name="SimplifyBooleanExpression"/>
+        <module name="IllegalThrows">
+            <property name="illegalClassNames" value="java.lang.Error, java.lang.RuntimeException,java.lang.Throwable"/>
+        </module>
+        <module name="SimplifyBooleanReturn"/>
+        <module name="AnnotationUseStyle"/>
+        <module name="UpperEll"/>
+        <module name="NeedBraces"/>
+        <module name="UnusedImports"/>
+        <module name="EmptyStatement"/>
+        <module name="MultipleVariableDeclarations"/>
+        <module name="PackageAnnotation"/>
+        <module name="IllegalType">
+            <property name="tokens" value="METHOD_DEF,PARAMETER_DEF,VARIABLE_DEF"/>
+            <property name="format" value="DontCheckForAbstractClasses"/>
+        </module>
+        <module name="MutableException"/>
+        <module name="ParameterNumber">
+            <property name="max" value="7"/>
+            <property name="tokens" value="METHOD_DEF"/>
+        </module>
+        <module name="AvoidNestedBlocks"/>
+        <module name="InnerAssignment"/>
+        <module name="NestedForDepth"/>
+        <module name="NestedIfDepth">
+            <property name="max" value="2"/>
+        </module>
+        <module name="NestedTryDepth"/>
+        <module name="RedundantThrows">
+            <property name="allowUnchecked" value="true"/>
+            <property name="suppressLoadErrors" value="true"/>
+        </module>
+        <module name="FinalClass"/>
+        <module name="InterfaceIsType"/>
+        <module name="ClassFanOutComplexity">
+            <property name="max" value="30"/>
+        </module>
+        <module name="CyclomaticComplexity"/>
+        <module name="NPathComplexity"/>
+        <module name="ParameterNumber">
+            <property name="max" value="13"/>
+            <property name="tokens" value="CTOR_DEF"/>
+        </module>
+        <module name="IllegalInstantiation">
+            <property name="classes"
+                      value="java.lang.Boolean,java.lang.Integer,java.lang.Long,java.lang.Byte,java.lang.Short,java.lang.Character,java.lang.Double,java.lang.Float"/>
+        </module>
+        <module name="SuppressWarnings">
+            <property name="format" value="^boxing$"/>
+        </module>
+        <module name="MissingDeprecated"/>
+        <module name="MissingOverride"/>
+        <module name="RedundantImport"/>
+        <module name="RedundantModifier"/>
+        <module name="AnonInnerLength">
+            <property name="max" value="30"/>
+        </module>
+        <module name="RegexpSinglelineJava">
+            <property name="format" value="@Ignore"/>
+            <property name="ignoreComments" value="true"/>
+        </module>
+        <module name="RegexpSinglelineJava">
+            <property name="severity" value="info"/>
+            <property name="format" value="System\.out\.print(ln)?"/>
+            <property name="ignoreComments" value="true"/>
+        </module>
+        <module name="RegexpSinglelineJava">
+            <property name="severity" value="info"/>
+            <property name="format" value="\.printStacktrace"/>
+            <property name="ignoreComments" value="true"/>
+        </module>
+        <module name="RegexpSinglelineJava">
+            <property name="severity" value="info"/>
+            <property name="format" value="System\.exit"/>
+            <property name="ignoreComments" value="true"/>
+        </module>
+        <module name="MethodLength">
+            <property name="max" value="200"/>
+        </module>
+        <module name="MethodCount">
+            <property name="maxTotal" value="30"/>
+            <property name="maxPrivate" value="21"/>
+            <property name="maxPackage" value="20"/>
+            <property name="maxProtected" value="20"/>
+            <property name="maxPublic" value="18"/>
+        </module>
+    </module>
+    <module name="FileLength">
+        <property name="max" value="1000"/>
+    </module>
+    <module name="StrictDuplicateCode"/>
+</module>

--- a/src/main/java/uk/gov/digital/ho/proving/income/api/FinancialStatusResource.java
+++ b/src/main/java/uk/gov/digital/ho/proving/income/api/FinancialStatusResource.java
@@ -57,7 +57,7 @@ public class FinancialStatusResource {
         validateApplicationRaisedDate(request.applicationRaisedDate());
 
         LocalDate startSearchDate = request.applicationRaisedDate().minusDays(NUMBER_OF_DAYS_INCOME);
-        LinkedHashMap<Individual, IncomeRecord> incomeRecords = financialStatusService.getIncomeRecords(applicants, startSearchDate, request.applicationRaisedDate());
+        Map<Individual, IncomeRecord> incomeRecords = financialStatusService.getIncomeRecords(applicants, startSearchDate, request.applicationRaisedDate());
 
 
         FinancialStatusCheckResponse response = financialStatusService.calculateResponse(request.applicationRaisedDate(), request.dependants(), incomeRecords);

--- a/src/main/java/uk/gov/digital/ho/proving/income/api/FinancialStatusService.java
+++ b/src/main/java/uk/gov/digital/ho/proving/income/api/FinancialStatusService.java
@@ -27,6 +27,8 @@ public class FinancialStatusService {
     }
 
     Map<Individual, IncomeRecord> getIncomeRecords(List<Applicant> applicants, LocalDate startSearchDate, LocalDate applicationRaisedDate) {
+        // The IPS UI relies on the first individual in the response being the applicant and the second the partner. This is why we must
+        // use a LinkedHashMap to ensure the order.
         Map<Individual, IncomeRecord> incomeRecords = new LinkedHashMap<>();
 
         for (Applicant applicant : applicants) {

--- a/src/main/java/uk/gov/digital/ho/proving/income/api/FinancialStatusService.java
+++ b/src/main/java/uk/gov/digital/ho/proving/income/api/FinancialStatusService.java
@@ -13,10 +13,7 @@ import uk.gov.digital.ho.proving.income.validator.IncomeValidationService;
 import uk.gov.digital.ho.proving.income.validator.domain.IncomeValidationRequest;
 
 import java.time.LocalDate;
-import java.util.ArrayList;
-import java.util.LinkedHashMap;
-import java.util.LinkedList;
-import java.util.List;
+import java.util.*;
 
 @Service
 public class FinancialStatusService {
@@ -29,8 +26,8 @@ public class FinancialStatusService {
         this.incomeValidationService = incomeValidationService;
     }
 
-    LinkedHashMap<Individual, IncomeRecord> getIncomeRecords(List<Applicant> applicants, LocalDate startSearchDate, LocalDate applicationRaisedDate) {
-        LinkedHashMap<Individual, IncomeRecord> incomeRecords = new LinkedHashMap<>();
+    Map<Individual, IncomeRecord> getIncomeRecords(List<Applicant> applicants, LocalDate startSearchDate, LocalDate applicationRaisedDate) {
+        Map<Individual, IncomeRecord> incomeRecords = new LinkedHashMap<>();
 
         for (Applicant applicant : applicants) {
 
@@ -45,7 +42,7 @@ public class FinancialStatusService {
         return incomeRecords;
     }
 
-    FinancialStatusCheckResponse calculateResponse(LocalDate applicationRaisedDate, Integer dependants, LinkedHashMap<Individual, IncomeRecord> incomeRecords) {
+    FinancialStatusCheckResponse calculateResponse(LocalDate applicationRaisedDate, Integer dependants, Map<Individual, IncomeRecord> incomeRecords) {
 
         List<Individual> individuals = new LinkedList<>(incomeRecords.keySet());
 

--- a/src/main/java/uk/gov/digital/ho/proving/income/application/ApplicationExceptions.java
+++ b/src/main/java/uk/gov/digital/ho/proving/income/application/ApplicationExceptions.java
@@ -17,7 +17,7 @@ public interface ApplicationExceptions {
     }
 
     class EarningsServiceNoUniqueMatchException extends RuntimeException {
-        private String nino;
+        private final String nino;
         public EarningsServiceNoUniqueMatchException(String nino) {
             this.nino = nino;
         }

--- a/src/main/java/uk/gov/digital/ho/proving/income/audit/statistics/PassRateStatistics.java
+++ b/src/main/java/uk/gov/digital/ho/proving/income/audit/statistics/PassRateStatistics.java
@@ -2,7 +2,6 @@ package uk.gov.digital.ho.proving.income.audit.statistics;
 
 import lombok.Builder;
 import lombok.Data;
-import lombok.experimental.Accessors;
 
 import java.time.LocalDate;
 

--- a/src/main/java/uk/gov/digital/ho/proving/income/hmrc/domain/Income.java
+++ b/src/main/java/uk/gov/digital/ho/proving/income/hmrc/domain/Income.java
@@ -10,7 +10,6 @@ import lombok.experimental.Accessors;
 
 import java.math.BigDecimal;
 import java.time.LocalDate;
-import java.util.Objects;
 
 @Getter
 @AllArgsConstructor

--- a/src/main/java/uk/gov/digital/ho/proving/income/validator/CatASalariedMonthlyIncomeValidator.java
+++ b/src/main/java/uk/gov/digital/ho/proving/income/validator/CatASalariedMonthlyIncomeValidator.java
@@ -25,6 +25,7 @@ public class CatASalariedMonthlyIncomeValidator implements IncomeValidator {
     private static final String CATEGORY = "A";
 
     @Override
+    @SuppressWarnings("StrictDuplicateCode") // Looks very like CatASalariedWeeklyIncomeValidator but there's no obvious way of consolidating them.
     public IncomeValidationResult validate(IncomeValidationRequest incomeValidationRequest) {
 
         ApplicantIncome applicantIncome = incomeValidationRequest.applicantIncome();

--- a/src/main/java/uk/gov/digital/ho/proving/income/validator/CatASalariedWeeklyIncomeValidator.java
+++ b/src/main/java/uk/gov/digital/ho/proving/income/validator/CatASalariedWeeklyIncomeValidator.java
@@ -17,7 +17,7 @@ import static uk.gov.digital.ho.proving.income.validator.IncomeValidationHelper.
 @Service
 public class CatASalariedWeeklyIncomeValidator implements IncomeValidator {
 
-    private final static Integer WEEKS_OF_INCOME = 26;
+    private static final Integer WEEKS_OF_INCOME = 26;
     private static final String CALCULATION_TYPE = "Category A Weekly Salary";
     private static final String CATEGORY = "A";
 

--- a/src/main/java/uk/gov/digital/ho/proving/income/validator/CatBNonSalariedIncomeValidator.java
+++ b/src/main/java/uk/gov/digital/ho/proving/income/validator/CatBNonSalariedIncomeValidator.java
@@ -11,7 +11,6 @@ import java.math.BigDecimal;
 import java.time.LocalDate;
 import java.util.List;
 import java.util.Map;
-import java.util.stream.Collectors;
 
 import static uk.gov.digital.ho.proving.income.validator.IncomeValidationHelper.getAllPayeIncomes;
 import static uk.gov.digital.ho.proving.income.validator.domain.IncomeValidationStatus.CATB_NON_SALARIED_BELOW_THRESHOLD;

--- a/src/main/java/uk/gov/digital/ho/proving/income/validator/CatBSalariedIncomeValidator.java
+++ b/src/main/java/uk/gov/digital/ho/proving/income/validator/CatBSalariedIncomeValidator.java
@@ -3,7 +3,6 @@ package uk.gov.digital.ho.proving.income.validator;
 import org.springframework.stereotype.Service;
 import uk.gov.digital.ho.proving.income.api.IncomeThresholdCalculator;
 import uk.gov.digital.ho.proving.income.hmrc.domain.Income;
-import uk.gov.digital.ho.proving.income.validator.domain.ApplicantIncome;
 import uk.gov.digital.ho.proving.income.validator.domain.IncomeValidationRequest;
 import uk.gov.digital.ho.proving.income.validator.domain.IncomeValidationResult;
 import uk.gov.digital.ho.proving.income.validator.domain.IncomeValidationStatus;

--- a/src/main/java/uk/gov/digital/ho/proving/income/validator/domain/IncomeValidationResult.java
+++ b/src/main/java/uk/gov/digital/ho/proving/income/validator/domain/IncomeValidationResult.java
@@ -1,6 +1,5 @@
 package uk.gov.digital.ho.proving.income.validator.domain;
 
-import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.ToString;

--- a/src/main/java/uk/gov/digital/ho/proving/income/validator/domain/TaxYear.java
+++ b/src/main/java/uk/gov/digital/ho/proving/income/validator/domain/TaxYear.java
@@ -17,7 +17,7 @@ import java.util.regex.Pattern;
 @Getter
 @Accessors(fluent = true)
 @EqualsAndHashCode
-public class TaxYear {
+public final class TaxYear {
     private static final Pattern TAX_YEAR_PATTERN = Pattern.compile("^\\d{4}\\s*?-\\d{2,4}$");
 
     private static final MonthDay TAX_YEAR_START_MONTH_DAY = MonthDay.of(Month.APRIL, 6);

--- a/src/main/java/uk/gov/digital/ho/proving/income/validator/domain/TaxYear.java
+++ b/src/main/java/uk/gov/digital/ho/proving/income/validator/domain/TaxYear.java
@@ -6,7 +6,10 @@ import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.experimental.Accessors;
 
-import java.time.*;
+import java.time.LocalDate;
+import java.time.Month;
+import java.time.MonthDay;
+import java.time.Year;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 


### PR DESCRIPTION
In my previous PR https://github.com/UKHomeOffice/pttg-ip-api/pull/161 I had given the AuditClient 10 constructor arguments and the build did not fail. This showed that we don't have any static code analysis in this project so I've put CheckStyle in, using the same config as rps-service.

I have then fixed the following CheckStyle issues:

- Declaring variables, return values or parameters of type 'LinkedHashMap' is not allowed.
- The field 'nino' must be declared final - exception extension
- Unused imports
- 'static' modifier out of order with the JLS suggestions
- Class TaxYear should be declared as final (presumably as it is meant to be immutable)

And added a SuppressWarnings for this one because I can't think of an elegeant resolution:
- CatASalariedWeeklyIncomeValidator.java:22: Found duplicate of 12 lines in /home/owainroberts/pttg/pttg-ip-api/src/main/java/uk/gov/digital/ho/proving/income/validator/CatASalariedMonthlyIncomeValidator.java
