### PR TITLE
EE-19133 factored out an AuditClientEndpointProperties class 

### DIFF
--- a/src/main/java/uk/gov/digital/ho/proving/income/audit/AuditClient.java
+++ b/src/main/java/uk/gov/digital/ho/proving/income/audit/AuditClient.java
@@ -3,7 +3,6 @@ package uk.gov.digital.ho.proving.income.audit;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.beans.factory.annotation.Value;
 import org.springframework.core.ParameterizedTypeReference;
 import org.springframework.http.HttpEntity;
 import org.springframework.http.HttpHeaders;
@@ -16,6 +15,7 @@ import org.springframework.web.client.RestClientException;
 import org.springframework.web.client.RestTemplate;
 import org.springframework.web.util.UriComponentsBuilder;
 import uk.gov.digital.ho.proving.income.api.RequestData;
+import uk.gov.digital.ho.proving.income.audit.statistics.AuditClientEndpointProperties;
 
 import java.net.URI;
 import java.time.Clock;
@@ -50,18 +50,15 @@ public class AuditClient {
     AuditClient(Clock clock,
                 RestTemplate restTemplate,
                 RequestData requestData,
-                @Value("${pttg.audit.endpoint}") String auditEndpoint,
-                       @Value("${audit.history.endpoint}") String auditHistoryEndpoint,
-                       @Value("${audit.archive.endpoint}") String auditArchiveEndpoint,
-                       @Value("${audit.archive.history.pagesize}") int historyPagesize,
-                       ObjectMapper mapper) {
+                AuditClientEndpointProperties endpointProperties,
+                ObjectMapper mapper) {
         this.clock = clock;
         this.restTemplate = restTemplate;
         this.requestData = requestData;
-        this.auditEndpoint = auditEndpoint;
-        this.auditHistoryEndpoint = auditHistoryEndpoint;
-        this.auditArchiveEndpoint = auditArchiveEndpoint;
-        this.historyPageSize = historyPagesize;
+        this.auditEndpoint = endpointProperties.getAuditEndpoint();
+        this.auditHistoryEndpoint = endpointProperties.getHistoryEndpoint();
+        this.auditArchiveEndpoint = endpointProperties.getArchiveEndpoint();
+        this.historyPageSize = endpointProperties.getArchiveHistoryPageSize();
         this.mapper = mapper;
     }
 

--- a/src/main/java/uk/gov/digital/ho/proving/income/audit/statistics/AuditClientEndpointProperties.java
+++ b/src/main/java/uk/gov/digital/ho/proving/income/audit/statistics/AuditClientEndpointProperties.java
@@ -1,0 +1,23 @@
+package uk.gov.digital.ho.proving.income.audit.statistics;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.context.annotation.Configuration;
+
+
+@Configuration
+@ConfigurationProperties(prefix = "pttg.audit")
+@NoArgsConstructor
+@Setter
+@Getter
+public class AuditClientEndpointProperties {
+
+    private String auditEndpoint;
+    private String historyEndpoint;
+    private String archiveEndpoint;
+    private int archiveHistoryPageSize;
+}
+
+

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -56,7 +56,11 @@ hmrc.service.retry.delay=1000
 #
 pttg.audit.port=8083
 pttg.audit.url=http://localhost:${pttg.audit.port}
-pttg.audit.endpoint=${pttg.audit.url}/audit
+pttg.audit.audit-endpoint=${pttg.audit.url}/audit
+pttg.audit.history-endpoint=${pttg.audit.url}/history
+pttg.audit.archive-endpoint=${pttg.audit.url}/archive
+
+pttg.audit.archive-history-page-size=100
 
 audit.service.auth=pttg-ip-hmrc:abc123
 
@@ -67,8 +71,5 @@ auditing.deployment.name=pttg-ip-api
 auditing.deployment.namespace=local
 
 audit.history.months=6
-audit.history.endpoint=${pttg.audit.url}/history
-audit.archive.endpoint=${pttg.audit.url}/archive
 
 audit.history.passratestats.pagesize=100
-audit.archive.history.pagesize=100

--- a/src/test/java/uk/gov/digital/ho/proving/income/audit/AuditClientTest.java
+++ b/src/test/java/uk/gov/digital/ho/proving/income/audit/AuditClientTest.java
@@ -4,9 +4,9 @@ import ch.qos.logback.classic.Level;
 import ch.qos.logback.classic.Logger;
 import ch.qos.logback.classic.spi.ILoggingEvent;
 import ch.qos.logback.classic.spi.LoggingEvent;
-import com.fasterxml.jackson.databind.JsonNode;
 import ch.qos.logback.core.Appender;
 import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import net.logstash.logback.marker.ObjectAppendingMarker;
 import org.junit.AfterClass;
@@ -27,6 +27,7 @@ import org.springframework.web.client.RestClientException;
 import org.springframework.web.client.RestTemplate;
 import uk.gov.digital.ho.proving.income.api.RequestData;
 import uk.gov.digital.ho.proving.income.application.LogEvent;
+import uk.gov.digital.ho.proving.income.audit.statistics.AuditClientEndpointProperties;
 import utils.LogCapturer;
 
 import java.io.IOException;
@@ -88,13 +89,16 @@ public class AuditClientTest {
 
     @Before
     public void setup() {
+        AuditClientEndpointProperties endpointProperties = new AuditClientEndpointProperties();
+        endpointProperties.setAuditEndpoint(SOME_ENDPOINT);
+        endpointProperties.setHistoryEndpoint(SOME_HISTORY_ENDPOINT);
+        endpointProperties.setArchiveEndpoint(SOME_ARCHIVE_ENDPOINT);
+        endpointProperties.setArchiveHistoryPageSize(HISTORY_PAGE_SIZE);
+
         auditClient = new AuditClient(Clock.fixed(Instant.parse("2017-08-29T08:00:00Z"), ZoneId.of("UTC")),
             mockRestTemplate,
             mockRequestData,
-            SOME_ENDPOINT,
-            SOME_HISTORY_ENDPOINT,
-            SOME_ARCHIVE_ENDPOINT,
-            HISTORY_PAGE_SIZE,
+            endpointProperties,
             mockObjectMapper);
 
         Logger rootLogger = (Logger) LoggerFactory.getLogger(AuditClient.class);

--- a/src/test/java/uk/gov/digital/ho/proving/income/audit/statistics/AuditClientEndpointPropertiesTest.java
+++ b/src/test/java/uk/gov/digital/ho/proving/income/audit/statistics/AuditClientEndpointPropertiesTest.java
@@ -1,0 +1,39 @@
+package uk.gov.digital.ho.proving.income.audit.statistics;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.TestPropertySource;
+import org.springframework.test.context.junit4.SpringRunner;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@RunWith(SpringRunner.class)
+@ContextConfiguration(classes = {AuditClientEndpointProperties.class, AuditClientEndpointPropertiesTest.TestConfig.class})
+@TestPropertySource(properties = {
+    "pttg.audit.url=http://somehost:8000",
+    "pttg.audit.audit-endpoint=${pttg.audit.url}/audit",
+    "pttg.audit.history-endpoint=${pttg.audit.url}/history",
+    "pttg.audit.archive-endpoint=${pttg.audit.url}/archive",
+    "pttg.audit.archive-history-page-size=1000"
+})
+public class AuditClientEndpointPropertiesTest {
+
+    @TestConfiguration
+    @EnableConfigurationProperties
+    public static class TestConfig {}
+
+    @Autowired
+    AuditClientEndpointProperties auditClientEndpointProperties;
+
+    @Test
+    public void shouldLoadEndpointProperties() {
+        assertThat(auditClientEndpointProperties.getAuditEndpoint()).isEqualTo("http://somehost:8000/audit");
+        assertThat(auditClientEndpointProperties.getHistoryEndpoint()).isEqualTo("http://somehost:8000/history");
+        assertThat(auditClientEndpointProperties.getArchiveEndpoint()).isEqualTo("http://somehost:8000/archive");
+        assertThat(auditClientEndpointProperties.getArchiveHistoryPageSize()).isEqualTo(1000);
+    }
+}


### PR DESCRIPTION
in order to reduce the number of constructor arguments for the AuditClient