### PR TITLE
Ee 19133 refactor for new stats calculation

### DIFF
--- a/src/main/java/uk/gov/digital/ho/proving/income/audit/AuditResultComparator.java
+++ b/src/main/java/uk/gov/digital/ho/proving/income/audit/AuditResultComparator.java
@@ -5,7 +5,7 @@ import org.springframework.stereotype.Component;
 import java.util.Comparator;
 
 @Component
-class AuditResultComparator implements Comparator<AuditResult> {
+public class AuditResultComparator implements Comparator<AuditResult> {
 
     private AuditResultTypeComparator auditResultTypeComparator;
 

--- a/src/main/java/uk/gov/digital/ho/proving/income/audit/AuditResultConsolidator.java
+++ b/src/main/java/uk/gov/digital/ho/proving/income/audit/AuditResultConsolidator.java
@@ -61,7 +61,7 @@ public class AuditResultConsolidator {
         return new AuditResultByNino(consolidatedResult.nino(), allCorrelationIds, consolidatedResult.date(), consolidatedResult.resultType());
     }
 
-    private AuditResult getAuditResult(List<AuditRecord> auditRecords) {
+    public AuditResult getAuditResult(List<AuditRecord> auditRecords) {
         String correlationId = auditRecords.get(0).getId();
         String nino = findingNino(auditRecords);
         LocalDate date = auditRecords.get(0).getDate().toLocalDate();

--- a/src/test/java/uk/gov/digital/ho/proving/income/api/PassRateStatisticsResourceIT.java
+++ b/src/test/java/uk/gov/digital/ho/proving/income/api/PassRateStatisticsResourceIT.java
@@ -1,7 +1,6 @@
 package uk.gov.digital.ho.proving.income.api;
 
 import com.google.common.collect.ImmutableMap;
-import org.apache.http.protocol.HTTP;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;

--- a/src/test/java/uk/gov/digital/ho/proving/income/audit/AuditResultConsolidatorIT.java
+++ b/src/test/java/uk/gov/digital/ho/proving/income/audit/AuditResultConsolidatorIT.java
@@ -8,9 +8,7 @@ import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.junit4.SpringRunner;
 
-import java.io.IOException;
 import java.time.LocalDate;
-import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;

--- a/src/test/java/uk/gov/digital/ho/proving/income/audit/AuditResultConsolidatorIT.java
+++ b/src/test/java/uk/gov/digital/ho/proving/income/audit/AuditResultConsolidatorIT.java
@@ -8,9 +8,12 @@ import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.junit4.SpringRunner;
 
+import java.io.IOException;
 import java.time.LocalDate;
+import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -279,4 +282,80 @@ public class AuditResultConsolidatorIT {
         assertThat(resultsByNino).contains(expected.get(0), expected.get(1));
     }
 
+    /*
+     * getAuditResult
+     */
+    @Test
+    public void getAuditResult_singleRequest_expectedAuditResultERROR() {
+        AuditRecord request = fileUtils.buildRequestRecord("some correlation id", "2019-02-25 12:01:02.003", "some nino");
+
+        AuditResult auditResult = auditResultConsolidator.getAuditResult(Collections.singletonList(request));
+        assertThat(auditResult).isEqualTo(new AuditResult("some correlation id", LocalDate.parse("2019-02-25"), "some nino", ERROR));
+    }
+
+    @Test
+    public void getAuditResult_singlePassResponse_expectedAuditResultPASS() {
+        AuditRecord passResponse = fileUtils.buildResponseRecord("some correlation id", "2019-02-25 12:01:02.003", "some nino", "true");
+
+        AuditResult auditResult = auditResultConsolidator.getAuditResult(Collections.singletonList(passResponse));
+        assertThat(auditResult).isEqualTo(new AuditResult("some correlation id", LocalDate.parse("2019-02-25"), "some nino", PASS));
+    }
+
+    @Test
+    public void getAuditResult_singleFailResponse_expectedAuditResultFAIL() {
+        AuditRecord failResponse = fileUtils.buildResponseRecord("some correlation id", "2019-02-25 12:01:02.003", "some nino", "false");
+
+        AuditResult auditResult = auditResultConsolidator.getAuditResult(Collections.singletonList(failResponse));
+        assertThat(auditResult).isEqualTo(new AuditResult("some correlation id", LocalDate.parse("2019-02-25"), "some nino", FAIL));
+    }
+
+    @Test
+    public void getAuditResult_singleNotFoundResponse_expectedAuditResultNOTFOUND() {
+        AuditRecord notFoundResponse = fileUtils.buildResponseNotFoundRecord("some correlation id", "2019-02-25 12:01:02.003");
+
+        AuditResult auditResult = auditResultConsolidator.getAuditResult(Collections.singletonList(notFoundResponse));
+        assertThat(auditResult).isEqualTo(new AuditResult("some correlation id", LocalDate.parse("2019-02-25"), "", NOTFOUND));
+    }
+
+    @Test
+    public void getAuditResult_requestAndPassResponse_expectedAuditResultPASS() {
+        AuditRecord request = fileUtils.buildRequestRecord("some correlation id", "2019-02-25 12:01:02.003", "some nino");
+        AuditRecord passResponse = fileUtils.buildResponseRecord("some correlation id", "2019-02-25 12:01:03.000", "some nino", "true");
+
+        AuditResult auditResult = auditResultConsolidator.getAuditResult(Arrays.asList(request, passResponse));
+
+        assertThat(auditResult).isEqualTo(new AuditResult("some correlation id", LocalDate.parse("2019-02-25"), "some nino", PASS));
+    }
+
+    @Test
+    public void getAuditResult_requestAndFailResponse_expectedAuditResultFAIL() {
+        AuditRecord request = fileUtils.buildRequestRecord("some correlation id", "2019-02-25 12:01:02.003", "some nino");
+        AuditRecord failResponse = fileUtils.buildResponseRecord("some correlation id", "2019-02-25 12:01:03.000", "some nino", "false");
+
+        AuditResult auditResult = auditResultConsolidator.getAuditResult(Arrays.asList(request, failResponse));
+
+        assertThat(auditResult).isEqualTo(new AuditResult("some correlation id", LocalDate.parse("2019-02-25"), "some nino", FAIL));
+    }
+
+    @Test
+    public void getAuditResult_requestAndNotFoundResponse_expectedAuditResultNOTFOUND() {
+        AuditRecord request = fileUtils.buildRequestRecord("some correlation id", "2019-02-25 12:01:02.003", "some nino");
+        AuditRecord notFoundResponse = fileUtils.buildResponseNotFoundRecord("some correlation id", "2019-02-25 12:01:03.000");
+
+        AuditResult auditResult = auditResultConsolidator.getAuditResult(Arrays.asList(request, notFoundResponse));
+
+        assertThat(auditResult).isEqualTo(new AuditResult("some correlation id", LocalDate.parse("2019-02-25"), "some nino", NOTFOUND));
+    }
+
+    @Test
+    public void getAuditResult_passAndFail_auditResultPASS() {
+        AuditRecord request1 = fileUtils.buildRequestRecord("some correlation id", "2019-02-25 12:01:02.003", "some nino");
+        AuditRecord passResponse = fileUtils.buildResponseRecord("some correlation id", "2019-02-25 12:01:03.000", "some nino", "true");
+        AuditRecord request2 = fileUtils.buildRequestRecord("some correlation id", "2019-02-25 12:01:02.003", "some nino");
+        AuditRecord failResponse = fileUtils.buildResponseRecord("some correlation id", "2019-02-25 12:01:03.000", "some nino", "false");
+
+        AuditResult auditResult = auditResultConsolidator.getAuditResult(Arrays.asList(request1, passResponse, request2, failResponse));
+
+        assertThat(auditResult).isEqualTo(new AuditResult("some correlation id", LocalDate.parse("2019-02-25"), "some nino", PASS));
+    }
 }


### PR DESCRIPTION
Simple changes to make the main PR for EE-19133 a bit smaller:

- Exposing the AuditResultComparator and the getAuditHistory method of the AuditResultConsolidator
- Adding unit tests for getAuditHistory
- Adding new utility methods to the PassRateStatisticsServiceIT