### PR TITLE
EE-21001 Add cutoff to getAllCorrelationIds request

### DIFF
--- a/src/main/java/uk/gov/digital/ho/proving/income/audit/statistics/PassRateStatisticsService.java
+++ b/src/main/java/uk/gov/digital/ho/proving/income/audit/statistics/PassRateStatisticsService.java
@@ -1,5 +1,6 @@
 package uk.gov.digital.ho.proving.income.audit.statistics;
 
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
 import uk.gov.digital.ho.proving.income.api.domain.TaxYear;
 import uk.gov.digital.ho.proving.income.audit.*;
@@ -26,16 +27,18 @@ public class PassRateStatisticsService {
     private final PassStatisticsCalculator calculator;
     private final AuditResultConsolidator consolidator;
     private final AuditResultComparator resultComparator;
+    private final int cutoffDays;
 
     public PassRateStatisticsService(AuditClient auditClient,
                                      PassStatisticsCalculator calculator,
                                      AuditResultConsolidator consolidator,
-                                     AuditResultComparator resultComparator) {
-
+                                     AuditResultComparator resultComparator,
+                                     @Value("${audit.history.cutoff.days}") int cutoffDays) {
         this.auditClient = auditClient;
         this.calculator = calculator;
         this.consolidator = consolidator;
         this.resultComparator = resultComparator;
+        this.cutoffDays = cutoffDays;
     }
 
     public PassRateStatistics generatePassRateStatistics(YearMonth calendarMonth) {
@@ -47,7 +50,8 @@ public class PassRateStatisticsService {
     }
 
     public PassRateStatistics generatePassRateStatistics(LocalDate fromDate, LocalDate toDate) {
-        List<String> allCorrelationIds = auditClient.getAllCorrelationIdsForEventType(AUDIT_EVENTS_TO_RETRIEVE);
+        LocalDate cutOffDate = toDate.plusDays(cutoffDays);
+        List<String> allCorrelationIds = auditClient.getAllCorrelationIdsForEventType(AUDIT_EVENTS_TO_RETRIEVE, cutOffDate);
 
         List<AuditResult> results = getAuditResults(allCorrelationIds);
 

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -73,3 +73,4 @@ auditing.deployment.name=pttg-ip-api
 auditing.deployment.namespace=local
 
 audit.history.months=6
+audit.history.cutoff.days=10

--- a/src/test/java/uk/gov/digital/ho/proving/income/audit/statistics/PassRateStatisticsServiceCalendarMonthTest.java
+++ b/src/test/java/uk/gov/digital/ho/proving/income/audit/statistics/PassRateStatisticsServiceCalendarMonthTest.java
@@ -33,7 +33,8 @@ public class PassRateStatisticsServiceCalendarMonthTest {
 
     @Before
     public void setUp() {
-        service = new PassRateStatisticsService(mockAuditClient, mockPassStatisticsCalculator, mockConsolidator, mockResultComparator);
+        int anyInt = 5;
+        service = new PassRateStatisticsService(mockAuditClient, mockPassStatisticsCalculator, mockConsolidator, mockResultComparator, anyInt);
     }
 
     @Test


### PR DESCRIPTION
Making the PassRateStatistics generatePassRateStatistics method fetch correlation IDs up to a cutoff date after which we would consider a request with the same Nino as a separate query that should not impact statistics in this range.

As IPS Statistics don't work in production currently I intend to merge this change once approved - there's more work to be done in this area.