### PR TITLE
EE 21001 PassStatisticsResultsConsolidator 

### DIFF
--- a/src/main/java/uk/gov/digital/ho/proving/income/audit/AuditResultTypeComparator.java
+++ b/src/main/java/uk/gov/digital/ho/proving/income/audit/AuditResultTypeComparator.java
@@ -9,7 +9,7 @@ import java.util.List;
 import static uk.gov.digital.ho.proving.income.audit.AuditResultType.*;
 
 @Component
-class AuditResultTypeComparator implements Comparator<AuditResultType> {
+public class AuditResultTypeComparator implements Comparator<AuditResultType> {
     private static final List<AuditResultType> naturalOrder
         = Arrays.asList(ERROR, NOTFOUND, FAIL, PASS);
 

--- a/src/main/java/uk/gov/digital/ho/proving/income/audit/statistics/AuditResultsGroupedByNino.java
+++ b/src/main/java/uk/gov/digital/ho/proving/income/audit/statistics/AuditResultsGroupedByNino.java
@@ -1,5 +1,6 @@
 package uk.gov.digital.ho.proving.income.audit.statistics;
 
+import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.experimental.Accessors;
 import uk.gov.digital.ho.proving.income.audit.AuditResult;
@@ -10,6 +11,7 @@ import static jersey.repackaged.com.google.common.collect.Lists.newArrayList;
 
 @Getter
 @Accessors(fluent = true)
+@EqualsAndHashCode
 public class AuditResultsGroupedByNino {
 
     private final List<AuditResult> results;

--- a/src/main/java/uk/gov/digital/ho/proving/income/audit/statistics/AuditResultsGroupedByNino.java
+++ b/src/main/java/uk/gov/digital/ho/proving/income/audit/statistics/AuditResultsGroupedByNino.java
@@ -1,14 +1,14 @@
 package uk.gov.digital.ho.proving.income.audit.statistics;
 
 import jersey.repackaged.com.google.common.collect.ForwardingList;
-import lombok.Getter;
 import uk.gov.digital.ho.proving.income.audit.AuditResult;
 
+import java.time.LocalDate;
 import java.util.List;
 
+import static java.util.Comparator.naturalOrder;
 import static jersey.repackaged.com.google.common.collect.Lists.newArrayList;
 
-@Getter
 public class AuditResultsGroupedByNino extends ForwardingList<AuditResult> {
 
     private final List<AuditResult> results;
@@ -24,5 +24,11 @@ public class AuditResultsGroupedByNino extends ForwardingList<AuditResult> {
     @Override
     protected List<AuditResult> delegate() {
         return results;
+    }
+
+    public LocalDate latestDate() {
+        return stream().map(AuditResult::date)
+                       .max(naturalOrder())
+                       .orElse(null);
     }
 }

--- a/src/main/java/uk/gov/digital/ho/proving/income/audit/statistics/AuditResultsGroupedByNino.java
+++ b/src/main/java/uk/gov/digital/ho/proving/income/audit/statistics/AuditResultsGroupedByNino.java
@@ -32,7 +32,7 @@ public class AuditResultsGroupedByNino extends ForwardingList<AuditResult> {
                        .orElse(null);
     }
 
-    public boolean afterCutoff(int cutoffDays, AuditResult auditResult) {
+    public boolean resultAfterCutoff(int cutoffDays, AuditResult auditResult) {
         if (latestDate() == null) {
             return false;
         }

--- a/src/main/java/uk/gov/digital/ho/proving/income/audit/statistics/AuditResultsGroupedByNino.java
+++ b/src/main/java/uk/gov/digital/ho/proving/income/audit/statistics/AuditResultsGroupedByNino.java
@@ -1,6 +1,5 @@
 package uk.gov.digital.ho.proving.income.audit.statistics;
 
-import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.experimental.Accessors;
 import uk.gov.digital.ho.proving.income.audit.AuditResult;
@@ -13,15 +12,21 @@ import static jersey.repackaged.com.google.common.collect.Lists.newArrayList;
 @Accessors(fluent = true)
 public class AuditResultsGroupedByNino {
 
-    private final String nino;
     private final List<AuditResult> results;
 
+    public AuditResultsGroupedByNino() {
+        results = newArrayList();
+    }
+
     public AuditResultsGroupedByNino(AuditResult result) {
-        nino = result.nino();
         results = newArrayList(result);
     }
 
     public void add(AuditResult result) {
         results.add(result);
+    }
+
+    public boolean isEmpty() {
+        return results.isEmpty();
     }
 }

--- a/src/main/java/uk/gov/digital/ho/proving/income/audit/statistics/AuditResultsGroupedByNino.java
+++ b/src/main/java/uk/gov/digital/ho/proving/income/audit/statistics/AuditResultsGroupedByNino.java
@@ -1,0 +1,26 @@
+package uk.gov.digital.ho.proving.income.audit.statistics;
+
+import lombok.Getter;
+import lombok.experimental.Accessors;
+import uk.gov.digital.ho.proving.income.audit.AuditResult;
+
+import java.util.List;
+
+import static jersey.repackaged.com.google.common.collect.Lists.newArrayList;
+
+@Getter
+@Accessors(fluent = true)
+public class AuditResultsGroupedByNino {
+
+    private final String nino;
+    private final List<AuditResult> results;
+
+    public AuditResultsGroupedByNino(AuditResult result) {
+        nino = result.nino();
+        results = newArrayList(result);
+    }
+
+    public void add(AuditResult result) {
+        results.add(result);
+    }
+}

--- a/src/main/java/uk/gov/digital/ho/proving/income/audit/statistics/AuditResultsGroupedByNino.java
+++ b/src/main/java/uk/gov/digital/ho/proving/income/audit/statistics/AuditResultsGroupedByNino.java
@@ -6,6 +6,7 @@ import lombok.experimental.Accessors;
 import uk.gov.digital.ho.proving.income.audit.AuditResult;
 
 import java.util.List;
+import java.util.stream.Stream;
 
 import static jersey.repackaged.com.google.common.collect.Lists.newArrayList;
 
@@ -30,5 +31,17 @@ public class AuditResultsGroupedByNino {
 
     public boolean isEmpty() {
         return results.isEmpty();
+    }
+
+    public Stream<AuditResult> stream() {
+        return results.stream();
+    }
+
+    public AuditResult get(int i) {
+        return results.get(i);
+    }
+
+    public int size() {
+        return results.size();
     }
 }

--- a/src/main/java/uk/gov/digital/ho/proving/income/audit/statistics/AuditResultsGroupedByNino.java
+++ b/src/main/java/uk/gov/digital/ho/proving/income/audit/statistics/AuditResultsGroupedByNino.java
@@ -1,19 +1,15 @@
 package uk.gov.digital.ho.proving.income.audit.statistics;
 
-import lombok.EqualsAndHashCode;
+import jersey.repackaged.com.google.common.collect.ForwardingList;
 import lombok.Getter;
-import lombok.experimental.Accessors;
 import uk.gov.digital.ho.proving.income.audit.AuditResult;
 
 import java.util.List;
-import java.util.stream.Stream;
 
 import static jersey.repackaged.com.google.common.collect.Lists.newArrayList;
 
 @Getter
-@Accessors(fluent = true)
-@EqualsAndHashCode
-public class AuditResultsGroupedByNino {
+public class AuditResultsGroupedByNino extends ForwardingList<AuditResult> {
 
     private final List<AuditResult> results;
 
@@ -25,23 +21,8 @@ public class AuditResultsGroupedByNino {
         results = newArrayList(result);
     }
 
-    public void add(AuditResult result) {
-        results.add(result);
-    }
-
-    public boolean isEmpty() {
-        return results.isEmpty();
-    }
-
-    public Stream<AuditResult> stream() {
-        return results.stream();
-    }
-
-    public AuditResult get(int i) {
-        return results.get(i);
-    }
-
-    public int size() {
-        return results.size();
+    @Override
+    protected List<AuditResult> delegate() {
+        return results;
     }
 }

--- a/src/main/java/uk/gov/digital/ho/proving/income/audit/statistics/AuditResultsGroupedByNino.java
+++ b/src/main/java/uk/gov/digital/ho/proving/income/audit/statistics/AuditResultsGroupedByNino.java
@@ -31,4 +31,11 @@ public class AuditResultsGroupedByNino extends ForwardingList<AuditResult> {
                        .max(naturalOrder())
                        .orElse(null);
     }
+
+    public boolean afterCutoff(int cutoffDays, AuditResult auditResult) {
+        if (latestDate() == null) {
+            return false;
+        }
+        return latestDate().plusDays(cutoffDays).isBefore(auditResult.date());
+    }
 }

--- a/src/main/java/uk/gov/digital/ho/proving/income/audit/statistics/AuditResultsGroupedByNino.java
+++ b/src/main/java/uk/gov/digital/ho/proving/income/audit/statistics/AuditResultsGroupedByNino.java
@@ -1,5 +1,6 @@
 package uk.gov.digital.ho.proving.income.audit.statistics;
 
+import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.experimental.Accessors;
 import uk.gov.digital.ho.proving.income.audit.AuditResult;

--- a/src/main/java/uk/gov/digital/ho/proving/income/audit/statistics/PassRateStatisticsService.java
+++ b/src/main/java/uk/gov/digital/ho/proving/income/audit/statistics/PassRateStatisticsService.java
@@ -66,6 +66,21 @@ public class PassRateStatisticsService {
             updateBestResults(bestResultsByNino, auditResult);
         }
         return new ArrayList<>(bestResultsByNino.values());
+
+        // Build up a map where each nino is the key and all the query results for that nino are stored in a list as the value
+        // Map<String, List<AuditResult>> resultsByNino = new HashMap<>();
+        // for (String correlationId : allCorrelationIds) {
+        // AuditResult auditResult = getAuditResultForCorrelationId(correlationId);
+        //     if(!resultsByNino.hasKey(auditResult.nino()) {
+        //         resultByNino.put(auditResult.nino(), new ArrayList<>(singletonList(auditResult)));
+        //     } else {
+        //         resultByNino.get(auditResult.nino()).add(auditResult)
+        //     }
+        // }
+        //
+        // Consolidate the results into a single list - for each nino, sort results by date, split list if any 10 day gaps,
+        // for each split list of results - calculate best earliest result and put into the final results list.
+        //
     }
 
     private AuditResult getAuditResultForCorrelationId(String correlationId) {

--- a/src/main/java/uk/gov/digital/ho/proving/income/audit/statistics/PassRateStatisticsService.java
+++ b/src/main/java/uk/gov/digital/ho/proving/income/audit/statistics/PassRateStatisticsService.java
@@ -67,6 +67,7 @@ public class PassRateStatisticsService {
         }
         return new ArrayList<>(bestResultsByNino.values());
 
+        // TODO EE-21001 - probable new routine:
         // Build up a map where each nino is the key and all the query results for that nino are stored in a list as the value
         // Map<String, List<AuditResult>> resultsByNino = new HashMap<>();
         // for (String correlationId : allCorrelationIds) {
@@ -80,7 +81,7 @@ public class PassRateStatisticsService {
         //
         // Consolidate the results into a single list - for each nino, sort results by date, split list if any 10 day gaps,
         // for each split list of results - calculate best earliest result and put into the final results list.
-        //
+        // return PassRateStatisticsConsolidator.consolidateResults(resultByNino.values())
     }
 
     private AuditResult getAuditResultForCorrelationId(String correlationId) {

--- a/src/main/java/uk/gov/digital/ho/proving/income/audit/statistics/PassRateStatisticsService.java
+++ b/src/main/java/uk/gov/digital/ho/proving/income/audit/statistics/PassRateStatisticsService.java
@@ -69,11 +69,11 @@ public class PassRateStatisticsService {
 
         // TODO EE-21001 - probable new routine:
         // Build up a map where each nino is the key and all the query results for that nino are stored in a list as the value
-        // Map<String, List<AuditResult>> resultsByNino = new HashMap<>();
+        // Map<String, AuditResultsGroupedByNino> resultsByNino = new HashMap<>();
         // for (String correlationId : allCorrelationIds) {
         // AuditResult auditResult = getAuditResultForCorrelationId(correlationId);
         //     if(!resultsByNino.hasKey(auditResult.nino()) {
-        //         resultByNino.put(auditResult.nino(), new ArrayList<>(singletonList(auditResult)));
+        //         resultByNino.put(auditResult.nino(), AuditResultsGroupedByNino(auditResult)));
         //     } else {
         //         resultByNino.get(auditResult.nino()).add(auditResult)
         //     }

--- a/src/main/java/uk/gov/digital/ho/proving/income/audit/statistics/PassStatisticsResultsConsolidator.java
+++ b/src/main/java/uk/gov/digital/ho/proving/income/audit/statistics/PassStatisticsResultsConsolidator.java
@@ -22,8 +22,9 @@ public class PassStatisticsResultsConsolidator {
         this.cutoffDays = cutoffDays;
     }
 
-    List<AuditResult> consolidateResults(List<List<AuditResult>> resultsGroupedByNino) {
+    List<AuditResult> consolidateResults(List<AuditResultsGroupedByNino> resultsGroupedByNino) {
         List<List<AuditResult>> separatedByCutoff = resultsGroupedByNino.stream()
+                                                                        .map(AuditResultsGroupedByNino::results)
                                                                         .map(this::separateResultsByCutoff)
                                                                         .flatMap(Collection::stream)
                                                                         .collect(Collectors.toList());

--- a/src/main/java/uk/gov/digital/ho/proving/income/audit/statistics/PassStatisticsResultsConsolidator.java
+++ b/src/main/java/uk/gov/digital/ho/proving/income/audit/statistics/PassStatisticsResultsConsolidator.java
@@ -42,14 +42,9 @@ public class PassStatisticsResultsConsolidator {
         AuditResultsGroupedByNino sameRequestResults = startNewGroup(groupedByCutoff);
 
         for (AuditResult auditResult : sortedByDate) {
-            long dayOfResult = auditResult.date().toEpochDay();
 
-            if (!sameRequestResults.isEmpty()) {
-                long dayOfPreviousResult = sameRequestResults.latestDate().toEpochDay();
-
-                if (afterCutoff(dayOfResult, dayOfPreviousResult)) {
-                    sameRequestResults = startNewGroup(groupedByCutoff);
-                }
+            if (sameRequestResults.afterCutoff(cutoffDays, auditResult)) {
+                sameRequestResults = startNewGroup(groupedByCutoff);
             }
             sameRequestResults.add(auditResult);
         }

--- a/src/main/java/uk/gov/digital/ho/proving/income/audit/statistics/PassStatisticsResultsConsolidator.java
+++ b/src/main/java/uk/gov/digital/ho/proving/income/audit/statistics/PassStatisticsResultsConsolidator.java
@@ -74,8 +74,4 @@ public class PassStatisticsResultsConsolidator {
                               .filter(result -> !result.isEmpty())
                               .collect(Collectors.toList());
     }
-
-    private boolean afterCutoff(long dayOfResult, long dayOfPreviousResult) {
-        return dayOfResult - dayOfPreviousResult >= cutoffDays;
-    }
 }

--- a/src/main/java/uk/gov/digital/ho/proving/income/audit/statistics/PassStatisticsResultsConsolidator.java
+++ b/src/main/java/uk/gov/digital/ho/proving/income/audit/statistics/PassStatisticsResultsConsolidator.java
@@ -43,7 +43,7 @@ public class PassStatisticsResultsConsolidator {
 
         for (AuditResult auditResult : sortedByDate) {
 
-            if (sameRequestResults.afterCutoff(cutoffDays, auditResult)) {
+            if (sameRequestResults.resultAfterCutoff(cutoffDays, auditResult)) {
                 sameRequestResults = startNewGroup(groupedByCutoff);
             }
             sameRequestResults.add(auditResult);

--- a/src/main/java/uk/gov/digital/ho/proving/income/audit/statistics/PassStatisticsResultsConsolidator.java
+++ b/src/main/java/uk/gov/digital/ho/proving/income/audit/statistics/PassStatisticsResultsConsolidator.java
@@ -7,7 +7,11 @@ import uk.gov.digital.ho.proving.income.audit.AuditResultComparator;
 
 import java.time.LocalDate;
 import java.util.*;
+import java.util.function.Function;
 import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+import static java.util.Collections.singletonList;
 
 @Component
 public class PassStatisticsResultsConsolidator {
@@ -21,43 +25,47 @@ public class PassStatisticsResultsConsolidator {
     }
 
     List<AuditResult> consolidateResults(List<List<AuditResult>> resultsGroupedByNino) {
-        List<AuditResult> consolidatedResults = new ArrayList<>();
-        for (List<AuditResult> results : resultsGroupedByNino) {
-            List<List<AuditResult>> separateResults = separateResultsByCutoff(results);
-            for (List<AuditResult> groupedResult : separateResults) {
-                AuditResult bestResult = groupedResult.stream()
-                                                      .max(resultComparator)
-                                                      .orElse(null);
-                consolidatedResults.add(bestResult);
-            }
-        }
-        return consolidatedResults;
+        List<List<AuditResult>> separatedByCutoff = resultsGroupedByNino.stream()
+                                                                        .map(this::separateResultsByCutoff)
+                                                                        .flatMap(Collection::stream)
+                                                                        .collect(Collectors.toList());
+
+        return separatedByCutoff.stream()
+                                .map(this::earliestBestResult)
+                                .collect(Collectors.toList());
     }
 
     List<List<AuditResult>> separateResultsByCutoff(List<AuditResult> results) {
-        if (results.isEmpty()) {
-            return Collections.emptyList();
-        }
-
-
         List<AuditResult> sortedByDate = results.stream()
                                                 .sorted(Comparator.comparing(AuditResult::date))
                                                 .collect(Collectors.toList());
 
         List<AuditResult> sameRequestResults = new ArrayList<>();
-        List<List<AuditResult>> groupedByCutoff = new ArrayList<>(Collections.singletonList(sameRequestResults));
+        List<List<AuditResult>> groupedByCutoff = new ArrayList<>(singletonList(sameRequestResults));
+
         for (AuditResult auditResult : sortedByDate) {
             LocalDate dateOfResult = auditResult.date();
             LocalDate dateOfLastResult = sameRequestResults.isEmpty() ? LocalDate.MAX : sameRequestResults.get(sameRequestResults.size() - 1).date();
-            if (dateOfResult.toEpochDay() - dateOfLastResult.toEpochDay() < cutoffDays) {
-                sameRequestResults.add(auditResult);
-            } else {
+
+            if (dateOfResult.toEpochDay() - dateOfLastResult.toEpochDay() >= cutoffDays) {
                 sameRequestResults = new ArrayList<>();
                 groupedByCutoff.add(sameRequestResults);
-                sameRequestResults.add(auditResult);
             }
+            sameRequestResults.add(auditResult);
         }
-        return groupedByCutoff;
+        return filterEmpty(groupedByCutoff);
 
+    }
+
+    private AuditResult earliestBestResult(List<AuditResult> auditResults) {
+        return auditResults.stream()
+                           .max(resultComparator)
+                           .orElse(null);
+    }
+
+    private List<List<AuditResult>> filterEmpty(List<List<AuditResult>> groupedByCutoff) {
+        return groupedByCutoff.stream()
+                              .filter(result -> !result.isEmpty())
+                              .collect(Collectors.toList());
     }
 }

--- a/src/main/java/uk/gov/digital/ho/proving/income/audit/statistics/PassStatisticsResultsConsolidator.java
+++ b/src/main/java/uk/gov/digital/ho/proving/income/audit/statistics/PassStatisticsResultsConsolidator.java
@@ -5,13 +5,11 @@ import org.springframework.stereotype.Component;
 import uk.gov.digital.ho.proving.income.audit.AuditResult;
 import uk.gov.digital.ho.proving.income.audit.AuditResultComparator;
 
-import java.time.LocalDate;
-import java.util.*;
-import java.util.function.Function;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Comparator;
+import java.util.List;
 import java.util.stream.Collectors;
-import java.util.stream.Stream;
-
-import static java.util.Collections.singletonList;
 
 @Component
 public class PassStatisticsResultsConsolidator {
@@ -36,25 +34,24 @@ public class PassStatisticsResultsConsolidator {
     }
 
     List<List<AuditResult>> separateResultsByCutoff(List<AuditResult> results) {
-        List<AuditResult> sortedByDate = results.stream()
-                                                .sorted(Comparator.comparing(AuditResult::date))
-                                                .collect(Collectors.toList());
+        List<AuditResult> sortedByDate = sortByDate(results);
+        List<List<AuditResult>> groupedByCutoff = new ArrayList<>();
 
-        List<AuditResult> sameRequestResults = new ArrayList<>();
-        List<List<AuditResult>> groupedByCutoff = new ArrayList<>(singletonList(sameRequestResults));
+        List<AuditResult> sameRequestResults = startNewGroup(groupedByCutoff);
 
         for (AuditResult auditResult : sortedByDate) {
-            LocalDate dateOfResult = auditResult.date();
-            LocalDate dateOfLastResult = sameRequestResults.isEmpty() ? LocalDate.MAX : sameRequestResults.get(sameRequestResults.size() - 1).date();
+            long dayOfResult = auditResult.date().toEpochDay();
 
-            if (dateOfResult.toEpochDay() - dateOfLastResult.toEpochDay() >= cutoffDays) {
-                sameRequestResults = new ArrayList<>();
-                groupedByCutoff.add(sameRequestResults);
+            if (!sameRequestResults.isEmpty()) {
+                long dayOfPreviousResult = getLast(sameRequestResults).date().toEpochDay();
+
+                if (afterCutoff(dayOfResult, dayOfPreviousResult)) {
+                    sameRequestResults = startNewGroup(groupedByCutoff);
+                }
             }
             sameRequestResults.add(auditResult);
         }
         return filterEmpty(groupedByCutoff);
-
     }
 
     private AuditResult earliestBestResult(List<AuditResult> auditResults) {
@@ -63,9 +60,29 @@ public class PassStatisticsResultsConsolidator {
                            .orElse(null);
     }
 
+    private List<AuditResult> sortByDate(List<AuditResult> results) {
+        return results.stream()
+                      .sorted(Comparator.comparing(AuditResult::date))
+                      .collect(Collectors.toList());
+    }
+
+    private List<AuditResult> startNewGroup(List<List<AuditResult>> groupedByCutoff) {
+        List<AuditResult> newGroup = new ArrayList<>();
+        groupedByCutoff.add(newGroup);
+        return newGroup;
+    }
+
     private List<List<AuditResult>> filterEmpty(List<List<AuditResult>> groupedByCutoff) {
         return groupedByCutoff.stream()
                               .filter(result -> !result.isEmpty())
                               .collect(Collectors.toList());
+    }
+
+    private AuditResult getLast(List<AuditResult> auditResults) {
+        return auditResults.get(auditResults.size() - 1);
+    }
+
+    private boolean afterCutoff(long dayOfResult, long dayOfPreviousResult) {
+        return dayOfResult - dayOfPreviousResult >= cutoffDays;
     }
 }

--- a/src/main/java/uk/gov/digital/ho/proving/income/audit/statistics/PassStatisticsResultsConsolidator.java
+++ b/src/main/java/uk/gov/digital/ho/proving/income/audit/statistics/PassStatisticsResultsConsolidator.java
@@ -11,6 +11,8 @@ import java.util.Comparator;
 import java.util.List;
 import java.util.stream.Collectors;
 
+import static java.util.stream.Collectors.toCollection;
+
 @Component
 public class PassStatisticsResultsConsolidator {
 
@@ -34,7 +36,7 @@ public class PassStatisticsResultsConsolidator {
     }
 
     List<AuditResultsGroupedByNino> separateResultsByCutoff(AuditResultsGroupedByNino results) {
-        List<AuditResult> sortedByDate = sortByDate(results);
+        AuditResultsGroupedByNino sortedByDate = sortByDate(results);
         List<AuditResultsGroupedByNino> groupedByCutoff = new ArrayList<>();
 
         AuditResultsGroupedByNino sameRequestResults = startNewGroup(groupedByCutoff);
@@ -60,10 +62,10 @@ public class PassStatisticsResultsConsolidator {
                            .orElse(null);
     }
 
-    private List<AuditResult> sortByDate(AuditResultsGroupedByNino results) {
+    private AuditResultsGroupedByNino sortByDate(AuditResultsGroupedByNino results) {
         return results.stream()
                       .sorted(Comparator.comparing(AuditResult::date))
-                      .collect(Collectors.toList());
+                      .collect(toCollection(AuditResultsGroupedByNino::new));
     }
 
     private AuditResultsGroupedByNino startNewGroup(List<AuditResultsGroupedByNino> groupedByCutoff) {

--- a/src/main/java/uk/gov/digital/ho/proving/income/audit/statistics/PassStatisticsResultsConsolidator.java
+++ b/src/main/java/uk/gov/digital/ho/proving/income/audit/statistics/PassStatisticsResultsConsolidator.java
@@ -45,7 +45,7 @@ public class PassStatisticsResultsConsolidator {
             long dayOfResult = auditResult.date().toEpochDay();
 
             if (!sameRequestResults.isEmpty()) {
-                long dayOfPreviousResult = getLast(sameRequestResults).date().toEpochDay();
+                long dayOfPreviousResult = sameRequestResults.latestDate().toEpochDay();
 
                 if (afterCutoff(dayOfResult, dayOfPreviousResult)) {
                     sameRequestResults = startNewGroup(groupedByCutoff);
@@ -78,10 +78,6 @@ public class PassStatisticsResultsConsolidator {
         return groupedByCutoff.stream()
                               .filter(result -> !result.isEmpty())
                               .collect(Collectors.toList());
-    }
-
-    private AuditResult getLast(AuditResultsGroupedByNino auditResults) {
-        return auditResults.get(auditResults.size() - 1);
     }
 
     private boolean afterCutoff(long dayOfResult, long dayOfPreviousResult) {

--- a/src/main/java/uk/gov/digital/ho/proving/income/audit/statistics/PassStatisticsResultsConsolidator.java
+++ b/src/main/java/uk/gov/digital/ho/proving/income/audit/statistics/PassStatisticsResultsConsolidator.java
@@ -1,0 +1,63 @@
+package uk.gov.digital.ho.proving.income.audit.statistics;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+import uk.gov.digital.ho.proving.income.audit.AuditResult;
+import uk.gov.digital.ho.proving.income.audit.AuditResultComparator;
+
+import java.time.LocalDate;
+import java.util.*;
+import java.util.stream.Collectors;
+
+@Component
+public class PassStatisticsResultsConsolidator {
+
+    private final AuditResultComparator resultComparator;
+    private final int cutoffDays;
+
+    PassStatisticsResultsConsolidator(AuditResultComparator resultComparator, @Value("${audit.history.cutoff.days}") int cutoffDays) {
+        this.resultComparator = resultComparator;
+        this.cutoffDays = cutoffDays;
+    }
+
+    List<AuditResult> consolidateResults(Map<String, List<AuditResult>> resultsByNino) { // TODO OJR EE-21001 2019-08-01 This might be better as a list of lists
+        List<AuditResult> consolidatedResults = new ArrayList<>();
+        for (List<AuditResult> results : resultsByNino.values()) {
+            List<List<AuditResult>> separateResults = separateResultsByCutoff(results);
+            for (List<AuditResult> groupedResult : separateResults) {
+                AuditResult bestResult = groupedResult.stream()
+                                                      .max(resultComparator)
+                                                      .orElse(null);
+                consolidatedResults.add(bestResult);
+            }
+        }
+        return consolidatedResults;
+    }
+
+    List<List<AuditResult>> separateResultsByCutoff(List<AuditResult> results) {
+        if (results.isEmpty()) {
+            return Collections.emptyList();
+        }
+
+
+        List<AuditResult> sortedByDate = results.stream()
+                                                .sorted(Comparator.comparing(AuditResult::date))
+                                                .collect(Collectors.toList());
+
+        List<AuditResult> sameRequestResults = new ArrayList<>();
+        List<List<AuditResult>> groupedByCutoff = new ArrayList<>(Collections.singletonList(sameRequestResults));
+        for (AuditResult auditResult : sortedByDate) {
+            LocalDate dateOfResult = auditResult.date();
+            LocalDate dateOfLastResult = sameRequestResults.isEmpty() ? LocalDate.MAX : sameRequestResults.get(sameRequestResults.size() - 1).date();
+            if (dateOfResult.toEpochDay() - dateOfLastResult.toEpochDay() < cutoffDays) {
+                sameRequestResults.add(auditResult);
+            } else {
+                sameRequestResults = new ArrayList<>();
+                groupedByCutoff.add(sameRequestResults);
+                sameRequestResults.add(auditResult);
+            }
+        }
+        return groupedByCutoff;
+
+    }
+}

--- a/src/main/java/uk/gov/digital/ho/proving/income/audit/statistics/PassStatisticsResultsConsolidator.java
+++ b/src/main/java/uk/gov/digital/ho/proving/income/audit/statistics/PassStatisticsResultsConsolidator.java
@@ -55,15 +55,13 @@ public class PassStatisticsResultsConsolidator {
     }
 
     private AuditResult earliestBestResult(AuditResultsGroupedByNino auditResults) {
-        return auditResults.results()
-                           .stream()
+        return auditResults.stream()
                            .max(resultComparator)
                            .orElse(null);
     }
 
     private List<AuditResult> sortByDate(AuditResultsGroupedByNino results) {
-        return results.results()
-                      .stream()
+        return results.stream()
                       .sorted(Comparator.comparing(AuditResult::date))
                       .collect(Collectors.toList());
     }
@@ -81,7 +79,7 @@ public class PassStatisticsResultsConsolidator {
     }
 
     private AuditResult getLast(AuditResultsGroupedByNino auditResults) {
-        return auditResults.results().get(auditResults.results().size() - 1);
+        return auditResults.get(auditResults.size() - 1);
     }
 
     private boolean afterCutoff(long dayOfResult, long dayOfPreviousResult) {

--- a/src/main/java/uk/gov/digital/ho/proving/income/audit/statistics/PassStatisticsResultsConsolidator.java
+++ b/src/main/java/uk/gov/digital/ho/proving/income/audit/statistics/PassStatisticsResultsConsolidator.java
@@ -20,7 +20,15 @@ public class PassStatisticsResultsConsolidator {
         this.cutoffDays = cutoffDays;
     }
 
-    List<AuditResult> consolidateResults(Map<String, List<AuditResult>> resultsByNino) { // TODO OJR EE-21001 2019-08-01 This might be better as a list of lists
+    List<AuditResult> consolidateResults(List<List<AuditResult>> resultsGroupedByNino) {
+        Map<String, List<AuditResult>> resultsByNino = resultsGroupedByNino.stream()
+                                                                           .collect(Collectors.toMap(resultGroupedByNino -> resultGroupedByNino.get(0).nino(),
+                                                                                                     resultGroupedByNino -> resultGroupedByNino,
+                                                                                                     (a, b) -> b));
+        return consolidateResults(resultsByNino);
+    }
+
+    List<AuditResult> consolidateResults(Map<String, List<AuditResult>> resultsByNino) {
         List<AuditResult> consolidatedResults = new ArrayList<>();
         for (List<AuditResult> results : resultsByNino.values()) {
             List<List<AuditResult>> separateResults = separateResultsByCutoff(results);

--- a/src/main/java/uk/gov/digital/ho/proving/income/audit/statistics/PassStatisticsResultsConsolidator.java
+++ b/src/main/java/uk/gov/digital/ho/proving/income/audit/statistics/PassStatisticsResultsConsolidator.java
@@ -21,16 +21,8 @@ public class PassStatisticsResultsConsolidator {
     }
 
     List<AuditResult> consolidateResults(List<List<AuditResult>> resultsGroupedByNino) {
-        Map<String, List<AuditResult>> resultsByNino = resultsGroupedByNino.stream()
-                                                                           .collect(Collectors.toMap(resultGroupedByNino -> resultGroupedByNino.get(0).nino(),
-                                                                                                     resultGroupedByNino -> resultGroupedByNino,
-                                                                                                     (a, b) -> b));
-        return consolidateResults(resultsByNino);
-    }
-
-    List<AuditResult> consolidateResults(Map<String, List<AuditResult>> resultsByNino) {
         List<AuditResult> consolidatedResults = new ArrayList<>();
-        for (List<AuditResult> results : resultsByNino.values()) {
+        for (List<AuditResult> results : resultsGroupedByNino) {
             List<List<AuditResult>> separateResults = separateResultsByCutoff(results);
             for (List<AuditResult> groupedResult : separateResults) {
                 AuditResult bestResult = groupedResult.stream()

--- a/src/main/java/uk/gov/digital/ho/proving/income/audit/statistics/PassStatisticsResultsConsolidator.java
+++ b/src/main/java/uk/gov/digital/ho/proving/income/audit/statistics/PassStatisticsResultsConsolidator.java
@@ -24,7 +24,6 @@ public class PassStatisticsResultsConsolidator {
 
     List<AuditResult> consolidateResults(List<AuditResultsGroupedByNino> resultsGroupedByNino) {
         List<List<AuditResult>> separatedByCutoff = resultsGroupedByNino.stream()
-                                                                        .map(AuditResultsGroupedByNino::results)
                                                                         .map(this::separateResultsByCutoff)
                                                                         .flatMap(Collection::stream)
                                                                         .collect(Collectors.toList());
@@ -34,7 +33,7 @@ public class PassStatisticsResultsConsolidator {
                                 .collect(Collectors.toList());
     }
 
-    List<List<AuditResult>> separateResultsByCutoff(List<AuditResult> results) {
+    List<List<AuditResult>> separateResultsByCutoff(AuditResultsGroupedByNino results) {
         List<AuditResult> sortedByDate = sortByDate(results);
         List<List<AuditResult>> groupedByCutoff = new ArrayList<>();
 
@@ -61,8 +60,9 @@ public class PassStatisticsResultsConsolidator {
                            .orElse(null);
     }
 
-    private List<AuditResult> sortByDate(List<AuditResult> results) {
-        return results.stream()
+    private List<AuditResult> sortByDate(AuditResultsGroupedByNino results) {
+        return results.results()
+                      .stream()
                       .sorted(Comparator.comparing(AuditResult::date))
                       .collect(Collectors.toList());
     }

--- a/src/test/java/uk/gov/digital/ho/proving/income/audit/statistics/AuditResultsGroupedByNinoTest.java
+++ b/src/test/java/uk/gov/digital/ho/proving/income/audit/statistics/AuditResultsGroupedByNinoTest.java
@@ -132,13 +132,13 @@ public class AuditResultsGroupedByNinoTest {
     }
 
     @Test
-    public void afterCutoff_empty_alwaysFalse() {
+    public void resultAfterCutoff_empty_alwaysFalse() {
         AuditResultsGroupedByNino emptyResults = new AuditResultsGroupedByNino();
-        assertThat(emptyResults.afterCutoff(ANY_INT, ANY_RESULT)).isFalse();
+        assertThat(emptyResults.resultAfterCutoff(ANY_INT, ANY_RESULT)).isFalse();
     }
 
     @Test
-    public void afterCutoff_oneDayBeforeCutoff_false() {
+    public void resultAfterCutoff_oneDayBeforeCutoff_false() {
         LocalDate someDate = LocalDate.now();
         int someCutoffDays = 5;
         LocalDate beforeCutoff = someDate.plusDays(someCutoffDays - 1);
@@ -146,11 +146,11 @@ public class AuditResultsGroupedByNinoTest {
         AuditResultsGroupedByNino groupedResults = new AuditResultsGroupedByNino(resultFor(someDate));
 
         AuditResult resultBeforeCutoff = resultFor(beforeCutoff);
-        assertThat(groupedResults.afterCutoff(someCutoffDays, resultBeforeCutoff)).isFalse();
+        assertThat(groupedResults.resultAfterCutoff(someCutoffDays, resultBeforeCutoff)).isFalse();
     }
 
     @Test
-    public void afterCutoff_cutOffDay_false() {
+    public void resultAfterCutoff_cutOffDay_false() {
         LocalDate someDate = LocalDate.now();
         int someCutoffDays = 5;
         LocalDate onCutoff = someDate.plusDays(someCutoffDays);
@@ -158,11 +158,11 @@ public class AuditResultsGroupedByNinoTest {
         AuditResultsGroupedByNino groupedResults = new AuditResultsGroupedByNino(resultFor(someDate));
 
         AuditResult resultOnCutoff = resultFor(onCutoff);
-        assertThat(groupedResults.afterCutoff(someCutoffDays, resultOnCutoff)).isFalse();
+        assertThat(groupedResults.resultAfterCutoff(someCutoffDays, resultOnCutoff)).isFalse();
     }
 
     @Test
-    public void afterCutoff_afterCutOffDay_true() {
+    public void resultAfterCutoff_afterCutOffDay_true() {
         LocalDate someDate = LocalDate.now();
         int someCutoffDays = 5;
         LocalDate afterCutoff = someDate.plusDays(someCutoffDays + 1);
@@ -170,7 +170,7 @@ public class AuditResultsGroupedByNinoTest {
         AuditResultsGroupedByNino groupedResults = new AuditResultsGroupedByNino(resultFor(someDate));
 
         AuditResult resultAfterCutoff = resultFor(afterCutoff);
-        assertThat(groupedResults.afterCutoff(someCutoffDays, resultAfterCutoff)).isTrue();
+        assertThat(groupedResults.resultAfterCutoff(someCutoffDays, resultAfterCutoff)).isTrue();
     }
 
     private AuditResult resultFor(LocalDate date) {

--- a/src/test/java/uk/gov/digital/ho/proving/income/audit/statistics/AuditResultsGroupedByNinoTest.java
+++ b/src/test/java/uk/gov/digital/ho/proving/income/audit/statistics/AuditResultsGroupedByNinoTest.java
@@ -91,14 +91,46 @@ public class AuditResultsGroupedByNinoTest {
 
     @Test
     public void size_singleElement_returnOne() {
-        AuditResultsGroupedByNino emptyResults = new AuditResultsGroupedByNino(ANY_RESULT);
-        assertThat(emptyResults.size()).isEqualTo(1);
+        AuditResultsGroupedByNino oneResult = new AuditResultsGroupedByNino(ANY_RESULT);
+        assertThat(oneResult.size()).isEqualTo(1);
     }
 
     @Test
     public void size_twoElements_returnTwo() {
-        AuditResultsGroupedByNino emptyResults = new AuditResultsGroupedByNino(ANY_RESULT);
-        emptyResults.add(ANY_RESULT);
-        assertThat(emptyResults.size()).isEqualTo(2);
+        AuditResultsGroupedByNino twoResults = new AuditResultsGroupedByNino(ANY_RESULT);
+        twoResults.add(ANY_RESULT);
+        assertThat(twoResults.size()).isEqualTo(2);
+    }
+
+    @Test
+    public void latestDate_noDates_returnNull() {
+        AuditResultsGroupedByNino emptyResult = new AuditResultsGroupedByNino();
+        assertThat(emptyResult.latestDate()).isNull();
+    }
+
+    @Test
+    public void latestDate_oneDate_returnDate() {
+        LocalDate someDate = LocalDate.now();
+        AuditResult someResult = new AuditResult("any correlation ID", someDate, ANY_NINO, ANY_RESULT_TYPE);
+
+        AuditResultsGroupedByNino singleResult = new AuditResultsGroupedByNino(someResult);
+        assertThat(singleResult.latestDate()).isEqualTo(someDate);
+    }
+
+    @Test
+    public void latestDate_multipleDates_returnLatest() {
+        LocalDate earlierDate = LocalDate.now();
+        LocalDate middleDate = earlierDate.plusDays(1);
+        LocalDate laterDate = middleDate.plusDays(1);
+
+        AuditResultsGroupedByNino groupedResults = new AuditResultsGroupedByNino(resultFor(earlierDate));
+        groupedResults.add(resultFor(laterDate));
+        groupedResults.add(resultFor(middleDate));
+
+        assertThat(groupedResults.latestDate()).isEqualTo(laterDate);
+    }
+
+    private AuditResult resultFor(LocalDate date) {
+        return new AuditResult("any correlation ID", date, ANY_NINO, ANY_RESULT_TYPE);
     }
 }

--- a/src/test/java/uk/gov/digital/ho/proving/income/audit/statistics/AuditResultsGroupedByNinoTest.java
+++ b/src/test/java/uk/gov/digital/ho/proving/income/audit/statistics/AuditResultsGroupedByNinoTest.java
@@ -15,6 +15,7 @@ public class AuditResultsGroupedByNinoTest {
     private static final AuditResultType ANY_RESULT_TYPE = AuditResultType.PASS;
     private static final String ANY_NINO = "BB112233A";
     private static final AuditResult ANY_RESULT = new AuditResult("any correlation ID", ANY_DATE, ANY_NINO, ANY_RESULT_TYPE);
+    private static final int ANY_INT = 9;
 
 
     @Test
@@ -128,6 +129,48 @@ public class AuditResultsGroupedByNinoTest {
         groupedResults.add(resultFor(middleDate));
 
         assertThat(groupedResults.latestDate()).isEqualTo(laterDate);
+    }
+
+    @Test
+    public void afterCutoff_empty_alwaysFalse() {
+        AuditResultsGroupedByNino emptyResults = new AuditResultsGroupedByNino();
+        assertThat(emptyResults.afterCutoff(ANY_INT, ANY_RESULT)).isFalse();
+    }
+
+    @Test
+    public void afterCutoff_oneDayBeforeCutoff_false() {
+        LocalDate someDate = LocalDate.now();
+        int someCutoffDays = 5;
+        LocalDate beforeCutoff = someDate.plusDays(someCutoffDays - 1);
+
+        AuditResultsGroupedByNino groupedResults = new AuditResultsGroupedByNino(resultFor(someDate));
+
+        AuditResult resultBeforeCutoff = resultFor(beforeCutoff);
+        assertThat(groupedResults.afterCutoff(someCutoffDays, resultBeforeCutoff)).isFalse();
+    }
+
+    @Test
+    public void afterCutoff_cutOffDay_false() {
+        LocalDate someDate = LocalDate.now();
+        int someCutoffDays = 5;
+        LocalDate onCutoff = someDate.plusDays(someCutoffDays);
+
+        AuditResultsGroupedByNino groupedResults = new AuditResultsGroupedByNino(resultFor(someDate));
+
+        AuditResult resultOnCutoff = resultFor(onCutoff);
+        assertThat(groupedResults.afterCutoff(someCutoffDays, resultOnCutoff)).isFalse();
+    }
+
+    @Test
+    public void afterCutoff_afterCutOffDay_true() {
+        LocalDate someDate = LocalDate.now();
+        int someCutoffDays = 5;
+        LocalDate afterCutoff = someDate.plusDays(someCutoffDays + 1);
+
+        AuditResultsGroupedByNino groupedResults = new AuditResultsGroupedByNino(resultFor(someDate));
+
+        AuditResult resultAfterCutoff = resultFor(afterCutoff);
+        assertThat(groupedResults.afterCutoff(someCutoffDays, resultAfterCutoff)).isTrue();
     }
 
     private AuditResult resultFor(LocalDate date) {

--- a/src/test/java/uk/gov/digital/ho/proving/income/audit/statistics/AuditResultsGroupedByNinoTest.java
+++ b/src/test/java/uk/gov/digital/ho/proving/income/audit/statistics/AuditResultsGroupedByNinoTest.java
@@ -52,4 +52,53 @@ public class AuditResultsGroupedByNinoTest {
         AuditResultsGroupedByNino nonEmptyGroupedResults = new AuditResultsGroupedByNino(ANY_RESULT);
         assertThat(nonEmptyGroupedResults.isEmpty()).isFalse();
     }
+
+    @Test
+    public void stream_someResults_streamResults() {
+        AuditResult someResult = new AuditResult("some correlation ID", LocalDate.now(), "AA112233A", AuditResultType.PASS);
+        AuditResult someOtherResult = new AuditResult("some other correlation ID", LocalDate.now(), "AA112233A", AuditResultType.FAIL);
+
+        AuditResultsGroupedByNino groupedResults = new AuditResultsGroupedByNino(someResult);
+        groupedResults.add(someOtherResult);
+
+        assertThat(groupedResults.stream()).containsExactlyInAnyOrder(someResult, someOtherResult);
+    }
+
+    @Test
+    public void get_zero_returnFirstElement() {
+        AuditResult someResult = new AuditResult("some correlation ID", LocalDate.now(), "AA112233A", AuditResultType.PASS);
+        AuditResultsGroupedByNino groupedResults = new AuditResultsGroupedByNino(someResult);
+
+        assertThat(groupedResults.get(0)).isEqualTo(someResult);
+    }
+
+    @Test
+    public void get_one_returnSecondElement() {
+        AuditResult someResult = new AuditResult("some correlation ID", LocalDate.now(), "AA112233A", AuditResultType.PASS);
+        AuditResult someOtherResult = new AuditResult("some other correlation ID", LocalDate.now(), "AA112233A", AuditResultType.FAIL);
+
+        AuditResultsGroupedByNino groupedResults = new AuditResultsGroupedByNino(someResult);
+        groupedResults.add(someOtherResult);
+
+        assertThat(groupedResults.get(1)).isEqualTo(someOtherResult);
+    }
+
+    @Test
+    public void size_empty_returnZero() {
+        AuditResultsGroupedByNino emptyResults = new AuditResultsGroupedByNino();
+        assertThat(emptyResults.size()).isEqualTo(0);
+    }
+
+    @Test
+    public void size_singleElement_returnOne() {
+        AuditResultsGroupedByNino emptyResults = new AuditResultsGroupedByNino(ANY_RESULT);
+        assertThat(emptyResults.size()).isEqualTo(1);
+    }
+
+    @Test
+    public void size_twoElements_returnTwo() {
+        AuditResultsGroupedByNino emptyResults = new AuditResultsGroupedByNino(ANY_RESULT);
+        emptyResults.add(ANY_RESULT);
+        assertThat(emptyResults.size()).isEqualTo(2);
+    }
 }

--- a/src/test/java/uk/gov/digital/ho/proving/income/audit/statistics/AuditResultsGroupedByNinoTest.java
+++ b/src/test/java/uk/gov/digital/ho/proving/income/audit/statistics/AuditResultsGroupedByNinoTest.java
@@ -16,13 +16,10 @@ public class AuditResultsGroupedByNinoTest {
     private static final String ANY_NINO = "BB112233A";
     private static final AuditResult ANY_RESULT = new AuditResult("any correlation ID", ANY_DATE, ANY_NINO, ANY_RESULT_TYPE);
 
-    @Test
-    public void constructor_someNino_hasNino() {
-        String someNino = "AA112233A";
-        AuditResult someResult = new AuditResult("any correlation ID", ANY_DATE, someNino, ANY_RESULT_TYPE);
 
-        AuditResultsGroupedByNino groupedResults = new AuditResultsGroupedByNino(someResult);
-        assertThat(groupedResults.nino()).isEqualTo(someNino);
+    @Test
+    public void constructor_noArgs_emptyResults() {
+        assertThat(new AuditResultsGroupedByNino().results()).isEmpty();
     }
 
     @Test
@@ -42,5 +39,17 @@ public class AuditResultsGroupedByNinoTest {
         assertThat(groupedResults.results())
             .hasSize(2)
             .contains(someResult);
+    }
+
+    @Test
+    public void isEmpty_empty_returnTrue() {
+        AuditResultsGroupedByNino emptyGroupedResults = new AuditResultsGroupedByNino();
+        assertThat(emptyGroupedResults.isEmpty()).isTrue();
+    }
+
+    @Test
+    public void isEmpty_nonEmpty_returnFalse() {
+        AuditResultsGroupedByNino nonEmptyGroupedResults = new AuditResultsGroupedByNino(ANY_RESULT);
+        assertThat(nonEmptyGroupedResults.isEmpty()).isFalse();
     }
 }

--- a/src/test/java/uk/gov/digital/ho/proving/income/audit/statistics/AuditResultsGroupedByNinoTest.java
+++ b/src/test/java/uk/gov/digital/ho/proving/income/audit/statistics/AuditResultsGroupedByNinoTest.java
@@ -18,8 +18,8 @@ public class AuditResultsGroupedByNinoTest {
 
 
     @Test
-    public void constructor_noArgs_emptyResults() {
-        assertThat(new AuditResultsGroupedByNino().results()).isEmpty();
+    public void constructor_noArgs_empty() {
+        assertThat(new AuditResultsGroupedByNino()).isEmpty();
     }
 
     @Test
@@ -27,7 +27,7 @@ public class AuditResultsGroupedByNinoTest {
         AuditResult someResult = new AuditResult("any correlation ID", ANY_DATE, ANY_NINO, ANY_RESULT_TYPE);
 
         AuditResultsGroupedByNino groupedResults = new AuditResultsGroupedByNino(someResult);
-        assertThat(groupedResults.results()).containsExactly(someResult);
+        assertThat(groupedResults).containsExactly(someResult);
     }
 
     @Test
@@ -36,7 +36,7 @@ public class AuditResultsGroupedByNinoTest {
 
         AuditResult someResult = new AuditResult("some correlation ID", LocalDate.now(), "AA112233A", AuditResultType.FAIL);
         groupedResults.add(someResult);
-        assertThat(groupedResults.results())
+        assertThat(groupedResults)
             .hasSize(2)
             .contains(someResult);
     }

--- a/src/test/java/uk/gov/digital/ho/proving/income/audit/statistics/AuditResultsGroupedByNinoTest.java
+++ b/src/test/java/uk/gov/digital/ho/proving/income/audit/statistics/AuditResultsGroupedByNinoTest.java
@@ -10,7 +10,6 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 public class AuditResultsGroupedByNinoTest {
 
-
     private static final LocalDate ANY_DATE = LocalDate.now();
     private static final AuditResultType ANY_RESULT_TYPE = AuditResultType.PASS;
     private static final String ANY_NINO = "BB112233A";
@@ -32,78 +31,6 @@ public class AuditResultsGroupedByNinoTest {
     }
 
     @Test
-    public void add_someResult_addedToResults() {
-        AuditResultsGroupedByNino groupedResults = new AuditResultsGroupedByNino(ANY_RESULT);
-
-        AuditResult someResult = new AuditResult("some correlation ID", LocalDate.now(), "AA112233A", AuditResultType.FAIL);
-        groupedResults.add(someResult);
-        assertThat(groupedResults)
-            .hasSize(2)
-            .contains(someResult);
-    }
-
-    @Test
-    public void isEmpty_empty_returnTrue() {
-        AuditResultsGroupedByNino emptyGroupedResults = new AuditResultsGroupedByNino();
-        assertThat(emptyGroupedResults.isEmpty()).isTrue();
-    }
-
-    @Test
-    public void isEmpty_nonEmpty_returnFalse() {
-        AuditResultsGroupedByNino nonEmptyGroupedResults = new AuditResultsGroupedByNino(ANY_RESULT);
-        assertThat(nonEmptyGroupedResults.isEmpty()).isFalse();
-    }
-
-    @Test
-    public void stream_someResults_streamResults() {
-        AuditResult someResult = new AuditResult("some correlation ID", LocalDate.now(), "AA112233A", AuditResultType.PASS);
-        AuditResult someOtherResult = new AuditResult("some other correlation ID", LocalDate.now(), "AA112233A", AuditResultType.FAIL);
-
-        AuditResultsGroupedByNino groupedResults = new AuditResultsGroupedByNino(someResult);
-        groupedResults.add(someOtherResult);
-
-        assertThat(groupedResults.stream()).containsExactlyInAnyOrder(someResult, someOtherResult);
-    }
-
-    @Test
-    public void get_zero_returnFirstElement() {
-        AuditResult someResult = new AuditResult("some correlation ID", LocalDate.now(), "AA112233A", AuditResultType.PASS);
-        AuditResultsGroupedByNino groupedResults = new AuditResultsGroupedByNino(someResult);
-
-        assertThat(groupedResults.get(0)).isEqualTo(someResult);
-    }
-
-    @Test
-    public void get_one_returnSecondElement() {
-        AuditResult someResult = new AuditResult("some correlation ID", LocalDate.now(), "AA112233A", AuditResultType.PASS);
-        AuditResult someOtherResult = new AuditResult("some other correlation ID", LocalDate.now(), "AA112233A", AuditResultType.FAIL);
-
-        AuditResultsGroupedByNino groupedResults = new AuditResultsGroupedByNino(someResult);
-        groupedResults.add(someOtherResult);
-
-        assertThat(groupedResults.get(1)).isEqualTo(someOtherResult);
-    }
-
-    @Test
-    public void size_empty_returnZero() {
-        AuditResultsGroupedByNino emptyResults = new AuditResultsGroupedByNino();
-        assertThat(emptyResults.size()).isEqualTo(0);
-    }
-
-    @Test
-    public void size_singleElement_returnOne() {
-        AuditResultsGroupedByNino oneResult = new AuditResultsGroupedByNino(ANY_RESULT);
-        assertThat(oneResult.size()).isEqualTo(1);
-    }
-
-    @Test
-    public void size_twoElements_returnTwo() {
-        AuditResultsGroupedByNino twoResults = new AuditResultsGroupedByNino(ANY_RESULT);
-        twoResults.add(ANY_RESULT);
-        assertThat(twoResults.size()).isEqualTo(2);
-    }
-
-    @Test
     public void latestDate_noDates_returnNull() {
         AuditResultsGroupedByNino emptyResult = new AuditResultsGroupedByNino();
         assertThat(emptyResult.latestDate()).isNull();
@@ -112,7 +39,7 @@ public class AuditResultsGroupedByNinoTest {
     @Test
     public void latestDate_oneDate_returnDate() {
         LocalDate someDate = LocalDate.now();
-        AuditResult someResult = new AuditResult("any correlation ID", someDate, ANY_NINO, ANY_RESULT_TYPE);
+        AuditResult someResult = resultFor(someDate);
 
         AuditResultsGroupedByNino singleResult = new AuditResultsGroupedByNino(someResult);
         assertThat(singleResult.latestDate()).isEqualTo(someDate);

--- a/src/test/java/uk/gov/digital/ho/proving/income/audit/statistics/AuditResultsGroupedByNinoTest.java
+++ b/src/test/java/uk/gov/digital/ho/proving/income/audit/statistics/AuditResultsGroupedByNinoTest.java
@@ -1,0 +1,46 @@
+package uk.gov.digital.ho.proving.income.audit.statistics;
+
+import org.junit.Test;
+import uk.gov.digital.ho.proving.income.audit.AuditResult;
+import uk.gov.digital.ho.proving.income.audit.AuditResultType;
+
+import java.time.LocalDate;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class AuditResultsGroupedByNinoTest {
+
+
+    private static final LocalDate ANY_DATE = LocalDate.now();
+    private static final AuditResultType ANY_RESULT_TYPE = AuditResultType.PASS;
+    private static final String ANY_NINO = "BB112233A";
+    private static final AuditResult ANY_RESULT = new AuditResult("any correlation ID", ANY_DATE, ANY_NINO, ANY_RESULT_TYPE);
+
+    @Test
+    public void constructor_someNino_hasNino() {
+        String someNino = "AA112233A";
+        AuditResult someResult = new AuditResult("any correlation ID", ANY_DATE, someNino, ANY_RESULT_TYPE);
+
+        AuditResultsGroupedByNino groupedResults = new AuditResultsGroupedByNino(someResult);
+        assertThat(groupedResults.nino()).isEqualTo(someNino);
+    }
+
+    @Test
+    public void constructor_someResult_setAsResults() {
+        AuditResult someResult = new AuditResult("any correlation ID", ANY_DATE, ANY_NINO, ANY_RESULT_TYPE);
+
+        AuditResultsGroupedByNino groupedResults = new AuditResultsGroupedByNino(someResult);
+        assertThat(groupedResults.results()).containsExactly(someResult);
+    }
+
+    @Test
+    public void add_someResult_addedToResults() {
+        AuditResultsGroupedByNino groupedResults = new AuditResultsGroupedByNino(ANY_RESULT);
+
+        AuditResult someResult = new AuditResult("some correlation ID", LocalDate.now(), "AA112233A", AuditResultType.FAIL);
+        groupedResults.add(someResult);
+        assertThat(groupedResults.results())
+            .hasSize(2)
+            .contains(someResult);
+    }
+}

--- a/src/test/java/uk/gov/digital/ho/proving/income/audit/statistics/PassStatisticsResultsConsolidatorIT.java
+++ b/src/test/java/uk/gov/digital/ho/proving/income/audit/statistics/PassStatisticsResultsConsolidatorIT.java
@@ -1,0 +1,151 @@
+package uk.gov.digital.ho.proving.income.audit.statistics;
+
+import com.google.common.collect.ImmutableMap;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.junit4.SpringRunner;
+import uk.gov.digital.ho.proving.income.audit.*;
+
+import java.time.LocalDate;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@RunWith(SpringRunner.class)
+@SpringBootTest(classes = {
+    PassStatisticsResultsConsolidator.class,
+    AuditResultComparator.class,
+    AuditResultTypeComparator.class
+})
+public class PassStatisticsResultsConsolidatorIT {
+
+    private static final int CUTOFF_DAYS = 10;
+
+    @Autowired
+    public PassStatisticsResultsConsolidator consolidator;
+    private static final LocalDate SOME_DATE = LocalDate.now();
+
+    @Test
+    public void consolidateResults_oneNinoWorseResultInRange_returnBetterResult() {
+        LocalDate someDate = LocalDate.now();
+        String someNino = "AA112233A";
+        AuditResult betterResult = new AuditResult("any correlation id", someDate, someNino, AuditResultType.PASS);
+
+        LocalDate withinCutoffDate = someDate.plusDays(CUTOFF_DAYS - 1);
+        AuditResult worseResultWithinRange = new AuditResult("any other correlation id", withinCutoffDate, someNino, AuditResultType.FAIL);
+
+        Map<String, List<AuditResult>> someResults = ImmutableMap.of(someNino, Arrays.asList(betterResult, worseResultWithinRange));
+
+        List<AuditResult> consolidatedResult = consolidator.consolidateResults(someResults);
+
+        assertThat(consolidatedResult).containsExactly(betterResult);
+    }
+
+    @Test
+    public void consolidateResults_oneNinoBetterResultInRange_returnBetterResult() {
+        LocalDate someDate = LocalDate.now();
+        String someNino = "AA112233A";
+        AuditResult worseResult = new AuditResult("any correlation id", someDate, someNino, AuditResultType.FAIL);
+
+        LocalDate withinCutoffDate = someDate.plusDays(CUTOFF_DAYS - 1);
+        AuditResult betterResultInRange = new AuditResult("any other correlation id", withinCutoffDate, someNino, AuditResultType.PASS);
+
+        Map<String, List<AuditResult>> someResults = ImmutableMap.of(someNino, Arrays.asList(worseResult, betterResultInRange));
+
+        List<AuditResult> consolidatedResult = consolidator.consolidateResults(someResults);
+
+        assertThat(consolidatedResult).containsExactly(betterResultInRange);
+    }
+
+    @Test
+    public void consolidateResults_twoNinosResultsAllInCutoff_returnTwoResults() {
+        LocalDate someDate = LocalDate.now();
+        LocalDate withinCutoffDate = someDate.plusDays(CUTOFF_DAYS - 1);
+
+        String someNino = "AA112233A";
+        AuditResult worseResult = new AuditResult("any correlation id", someDate, someNino, AuditResultType.NOTFOUND);
+        AuditResult betterResultInRange = new AuditResult("any correlation id", withinCutoffDate, someNino, AuditResultType.PASS);
+
+        String someOtherNino = "BB112233A";
+        AuditResult betterResult = new AuditResult("any correlation id", someDate, someOtherNino, AuditResultType.NOTFOUND);
+        AuditResult worseResultInRange = new AuditResult("any correlation id", withinCutoffDate, someOtherNino, AuditResultType.ERROR);
+
+        Map<String, List<AuditResult>> someResults = ImmutableMap.of(someNino, Arrays.asList(worseResult, betterResultInRange),
+                                                                     someOtherNino, Arrays.asList(betterResult, worseResultInRange));
+
+        List<AuditResult> consolidatedResult = consolidator.consolidateResults(someResults);
+        assertThat(consolidatedResult).containsExactlyInAnyOrder(betterResult, betterResultInRange);
+    }
+
+    @Test
+    public void consolidateResults_oneNinoResultsAfterCutoff_returnTwoResults() {
+        LocalDate afterCutoffDate = SOME_DATE.plusDays(CUTOFF_DAYS);
+
+        String someNino = "AA112233A";
+        AuditResult someResult = new AuditResult("any correlation id", SOME_DATE, someNino, AuditResultType.PASS);
+        AuditResult resultAfterCutoffDate = new AuditResult("any correlation id", afterCutoffDate, someNino, AuditResultType.FAIL);
+
+        Map<String, List<AuditResult>> someResults = ImmutableMap.of(someNino, Arrays.asList(someResult, resultAfterCutoffDate));
+
+        List<AuditResult> consolidatedResult = consolidator.consolidateResults(someResults);
+        assertThat(consolidatedResult).containsExactlyInAnyOrder(someResult, resultAfterCutoffDate);
+    }
+
+    @Test
+    public void consolidateResults_multipleNinosAndResults_splitWhenAfterCutoff() {
+        List<AuditResult> shouldBePassAndFail = passAndAFail();
+        List<AuditResult> shouldBeNotFoundAndError = notFoundAndAnError();
+        List<AuditResult> shouldBePass = Collections.singletonList(new AuditResult("any correlation id", SOME_DATE, "nino3", AuditResultType.PASS));
+
+        Map<String, List<AuditResult>> someResults = ImmutableMap.<String, List<AuditResult>>builder()
+            .put("nino1", shouldBePassAndFail)
+            .put("nino2", shouldBeNotFoundAndError)
+            .put("nino3", shouldBePass)
+            .build();
+
+        List<AuditResult> expectedResults = Arrays.asList(shouldBePassAndFail.get(1), shouldBePassAndFail.get(2),
+                                                          shouldBeNotFoundAndError.get(0), shouldBeNotFoundAndError.get(1),
+                                                          shouldBePass.get(0));
+
+
+        List<AuditResult> actualResults = consolidator.consolidateResults(someResults);
+
+        assertThat(actualResults).containsExactlyInAnyOrder(expectedResults.toArray(new AuditResult[]{}));
+    }
+
+    private List<AuditResult> passAndAFail() {
+        LocalDate date2 = withinCutoff(SOME_DATE);
+        LocalDate date3 = afterCutoff(date2);
+        LocalDate date4 = withinCutoff(date3);
+        return Arrays.asList(
+            new AuditResult("any correlation id", SOME_DATE, "nino1", AuditResultType.ERROR),
+            new AuditResult("any correlation id", date2, "nino1", AuditResultType.PASS),
+
+            new AuditResult("any correlation id", date3, "nino1", AuditResultType.FAIL),
+            new AuditResult("any correlation id", date4, "nino1", AuditResultType.NOTFOUND));
+    }
+
+    private List<AuditResult> notFoundAndAnError() {
+        LocalDate date2 = afterCutoff(SOME_DATE);
+        LocalDate date3 = withinCutoff(date2);
+
+        return Arrays.asList(
+            new AuditResult("any correlation id", SOME_DATE, "nino2", AuditResultType.ERROR),
+
+            new AuditResult("any correlation id", date2, "nino2", AuditResultType.NOTFOUND),
+            new AuditResult("any correlation id", date3, "nino2", AuditResultType.NOTFOUND));
+    }
+
+    private LocalDate withinCutoff(LocalDate date) {
+        return date.plusDays(CUTOFF_DAYS - 1);
+    }
+
+    private LocalDate afterCutoff(LocalDate date) {
+        return date.plusDays(CUTOFF_DAYS);
+    }
+}

--- a/src/test/java/uk/gov/digital/ho/proving/income/audit/statistics/PassStatisticsResultsConsolidatorIT.java
+++ b/src/test/java/uk/gov/digital/ho/proving/income/audit/statistics/PassStatisticsResultsConsolidatorIT.java
@@ -80,7 +80,7 @@ public class PassStatisticsResultsConsolidatorIT {
 
     @Test
     public void consolidateResults_oneNinoResultsAfterCutoff_returnTwoResults() {
-        LocalDate afterCutoffDate = SOME_DATE.plusDays(CUTOFF_DAYS);
+        LocalDate afterCutoffDate = SOME_DATE.plusDays(CUTOFF_DAYS + 1);
 
         AuditResult someResult = new AuditResult("any correlation id", SOME_DATE, SOME_NINO, AuditResultType.PASS);
         AuditResult resultAfterCutoffDate = new AuditResult("any correlation id", afterCutoffDate, SOME_NINO, AuditResultType.FAIL);
@@ -134,10 +134,10 @@ public class PassStatisticsResultsConsolidatorIT {
     }
 
     private LocalDate withinCutoff(LocalDate date) {
-        return date.plusDays(CUTOFF_DAYS - 1);
+        return date.plusDays(CUTOFF_DAYS);
     }
 
     private LocalDate afterCutoff(LocalDate date) {
-        return date.plusDays(CUTOFF_DAYS);
+        return date.plusDays(CUTOFF_DAYS + 1);
     }
 }

--- a/src/test/java/uk/gov/digital/ho/proving/income/audit/statistics/PassStatisticsResultsConsolidatorIT.java
+++ b/src/test/java/uk/gov/digital/ho/proving/income/audit/statistics/PassStatisticsResultsConsolidatorIT.java
@@ -101,9 +101,9 @@ public class PassStatisticsResultsConsolidatorIT {
 
         List<AuditResultsGroupedByNino> someResults = asList(shouldBePassAndFail, shouldBeNotFoundAndError, shouldBePass);
 
-        List<AuditResult> expectedResults = asList(shouldBePassAndFail.results().get(1), shouldBePassAndFail.results().get(2),
-                                                   shouldBeNotFoundAndError.results().get(0), shouldBeNotFoundAndError.results().get(1),
-                                                   shouldBePass.results().get(0));
+        List<AuditResult> expectedResults = asList(shouldBePassAndFail.get(1), shouldBePassAndFail.get(2),
+                                                   shouldBeNotFoundAndError.get(0), shouldBeNotFoundAndError.get(1),
+                                                   shouldBePass.get(0));
 
 
         List<AuditResult> actualResults = consolidator.consolidateResults(someResults);

--- a/src/test/java/uk/gov/digital/ho/proving/income/audit/statistics/PassStatisticsResultsConsolidatorIT.java
+++ b/src/test/java/uk/gov/digital/ho/proving/income/audit/statistics/PassStatisticsResultsConsolidatorIT.java
@@ -1,19 +1,17 @@
 package uk.gov.digital.ho.proving.income.audit.statistics;
 
-import com.google.common.collect.ImmutableList;
-import com.google.common.collect.ImmutableMap;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.context.junit4.SpringRunner;
-import uk.gov.digital.ho.proving.income.audit.*;
+import uk.gov.digital.ho.proving.income.audit.AuditResult;
+import uk.gov.digital.ho.proving.income.audit.AuditResultComparator;
+import uk.gov.digital.ho.proving.income.audit.AuditResultType;
+import uk.gov.digital.ho.proving.income.audit.AuditResultTypeComparator;
 
 import java.time.LocalDate;
-import java.util.Arrays;
-import java.util.Collections;
 import java.util.List;
-import java.util.Map;
 
 import static java.util.Arrays.asList;
 import static java.util.Collections.singletonList;
@@ -28,58 +26,45 @@ import static org.assertj.core.api.Assertions.assertThat;
 public class PassStatisticsResultsConsolidatorIT {
 
     private static final int CUTOFF_DAYS = 10;
+    private static final LocalDate SOME_DATE = LocalDate.now();
+    private static final String SOME_NINO = "AA112233A";
 
     @Autowired
     public PassStatisticsResultsConsolidator consolidator;
-    private static final LocalDate SOME_DATE = LocalDate.now();
 
     @Test
     public void consolidateResults_oneNinoWorseResultInRange_returnBetterResult() {
-        LocalDate someDate = LocalDate.now();
-        String someNino = "AA112233A";
-        AuditResult betterResult = new AuditResult("any correlation id", someDate, someNino, AuditResultType.PASS);
-
-        LocalDate withinCutoffDate = someDate.plusDays(CUTOFF_DAYS - 1);
-        AuditResult worseResultWithinRange = new AuditResult("any other correlation id", withinCutoffDate, someNino, AuditResultType.FAIL);
+        AuditResult betterResult = new AuditResult("any correlation id", SOME_DATE, SOME_NINO, AuditResultType.PASS);
+        AuditResult worseResultWithinRange = new AuditResult("any other correlation id", withinCutoff(SOME_DATE), SOME_NINO, AuditResultType.FAIL);
 
         List<List<AuditResult>> someResults = singletonList(asList(betterResult, worseResultWithinRange));
 
         List<AuditResult> consolidatedResult = consolidator.consolidateResults(someResults);
-
         assertThat(consolidatedResult).containsExactly(betterResult);
     }
 
     @Test
     public void consolidateResults_oneNinoBetterResultInRange_returnBetterResult() {
-        LocalDate someDate = LocalDate.now();
-        String someNino = "AA112233A";
-        AuditResult worseResult = new AuditResult("any correlation id", someDate, someNino, AuditResultType.FAIL);
-
-        LocalDate withinCutoffDate = someDate.plusDays(CUTOFF_DAYS - 1);
-        AuditResult betterResultInRange = new AuditResult("any other correlation id", withinCutoffDate, someNino, AuditResultType.PASS);
+        AuditResult worseResult = new AuditResult("any correlation id", SOME_DATE, SOME_NINO, AuditResultType.FAIL);
+        AuditResult betterResultInRange = new AuditResult("any other correlation id", withinCutoff(SOME_DATE), SOME_NINO, AuditResultType.PASS);
 
         List<List<AuditResult>> someResults = singletonList(asList(worseResult, betterResultInRange));
 
         List<AuditResult> consolidatedResult = consolidator.consolidateResults(someResults);
-
         assertThat(consolidatedResult).containsExactly(betterResultInRange);
     }
 
     @Test
     public void consolidateResults_twoNinosResultsAllInCutoff_returnTwoResults() {
-        LocalDate someDate = LocalDate.now();
-        LocalDate withinCutoffDate = someDate.plusDays(CUTOFF_DAYS - 1);
-
-        String someNino = "AA112233A";
-        AuditResult worseResult = new AuditResult("any correlation id", someDate, someNino, AuditResultType.NOTFOUND);
-        AuditResult betterResultInRange = new AuditResult("any correlation id", withinCutoffDate, someNino, AuditResultType.PASS);
+        AuditResult worseResult = new AuditResult("any correlation id", SOME_DATE, SOME_NINO, AuditResultType.NOTFOUND);
+        AuditResult betterResultInRange = new AuditResult("any correlation id", withinCutoff(SOME_DATE), SOME_NINO, AuditResultType.PASS);
 
         String someOtherNino = "BB112233A";
-        AuditResult betterResult = new AuditResult("any correlation id", someDate, someOtherNino, AuditResultType.NOTFOUND);
-        AuditResult worseResultInRange = new AuditResult("any correlation id", withinCutoffDate, someOtherNino, AuditResultType.ERROR);
+        AuditResult betterResult = new AuditResult("any correlation id", SOME_DATE, someOtherNino, AuditResultType.NOTFOUND);
+        AuditResult worseResultInRange = new AuditResult("any correlation id", withinCutoff(SOME_DATE), someOtherNino, AuditResultType.ERROR);
 
         List<List<AuditResult>> someResults = asList(asList(worseResult, betterResultInRange),
-                                                     asList(betterResult, worseResult));
+                                                     asList(betterResult, worseResultInRange));
 
         List<AuditResult> consolidatedResult = consolidator.consolidateResults(someResults);
         assertThat(consolidatedResult).containsExactlyInAnyOrder(betterResult, betterResultInRange);
@@ -89,9 +74,8 @@ public class PassStatisticsResultsConsolidatorIT {
     public void consolidateResults_oneNinoResultsAfterCutoff_returnTwoResults() {
         LocalDate afterCutoffDate = SOME_DATE.plusDays(CUTOFF_DAYS);
 
-        String someNino = "AA112233A";
-        AuditResult someResult = new AuditResult("any correlation id", SOME_DATE, someNino, AuditResultType.PASS);
-        AuditResult resultAfterCutoffDate = new AuditResult("any correlation id", afterCutoffDate, someNino, AuditResultType.FAIL);
+        AuditResult someResult = new AuditResult("any correlation id", SOME_DATE, SOME_NINO, AuditResultType.PASS);
+        AuditResult resultAfterCutoffDate = new AuditResult("any correlation id", afterCutoffDate, SOME_NINO, AuditResultType.FAIL);
 
         List<List<AuditResult>> someResults = singletonList(asList(someResult, resultAfterCutoffDate));
 
@@ -121,23 +105,21 @@ public class PassStatisticsResultsConsolidatorIT {
         LocalDate date2 = withinCutoff(SOME_DATE);
         LocalDate date3 = afterCutoff(date2);
         LocalDate date4 = withinCutoff(date3);
-        return asList(
-            new AuditResult("any correlation id", SOME_DATE, "nino1", AuditResultType.ERROR),
-            new AuditResult("any correlation id", date2, "nino1", AuditResultType.PASS),
+        return asList(new AuditResult("any correlation id", SOME_DATE, "nino1", AuditResultType.ERROR),
+                      new AuditResult("any correlation id", date2, "nino1", AuditResultType.PASS),
 
-            new AuditResult("any correlation id", date3, "nino1", AuditResultType.FAIL),
-            new AuditResult("any correlation id", date4, "nino1", AuditResultType.NOTFOUND));
+                      new AuditResult("any correlation id", date3, "nino1", AuditResultType.FAIL),
+                      new AuditResult("any correlation id", date4, "nino1", AuditResultType.NOTFOUND));
     }
 
     private List<AuditResult> notFoundAndAnError() {
         LocalDate date2 = afterCutoff(SOME_DATE);
         LocalDate date3 = withinCutoff(date2);
 
-        return asList(
-            new AuditResult("any correlation id", SOME_DATE, "nino2", AuditResultType.ERROR),
+        return asList(new AuditResult("any correlation id", SOME_DATE, "nino2", AuditResultType.ERROR),
 
-            new AuditResult("any correlation id", date2, "nino2", AuditResultType.NOTFOUND),
-            new AuditResult("any correlation id", date3, "nino2", AuditResultType.NOTFOUND));
+                      new AuditResult("any correlation id", date2, "nino2", AuditResultType.NOTFOUND),
+                      new AuditResult("any correlation id", date3, "nino2", AuditResultType.NOTFOUND));
     }
 
     private LocalDate withinCutoff(LocalDate date) {

--- a/src/test/java/uk/gov/digital/ho/proving/income/audit/statistics/PassStatisticsResultsConsolidatorIT.java
+++ b/src/test/java/uk/gov/digital/ho/proving/income/audit/statistics/PassStatisticsResultsConsolidatorIT.java
@@ -1,5 +1,6 @@
 package uk.gov.digital.ho.proving.income.audit.statistics;
 
+import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -14,6 +15,8 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 
+import static java.util.Arrays.asList;
+import static java.util.Collections.singletonList;
 import static org.assertj.core.api.Assertions.assertThat;
 
 @RunWith(SpringRunner.class)
@@ -39,7 +42,7 @@ public class PassStatisticsResultsConsolidatorIT {
         LocalDate withinCutoffDate = someDate.plusDays(CUTOFF_DAYS - 1);
         AuditResult worseResultWithinRange = new AuditResult("any other correlation id", withinCutoffDate, someNino, AuditResultType.FAIL);
 
-        Map<String, List<AuditResult>> someResults = ImmutableMap.of(someNino, Arrays.asList(betterResult, worseResultWithinRange));
+        List<List<AuditResult>> someResults = singletonList(asList(betterResult, worseResultWithinRange));
 
         List<AuditResult> consolidatedResult = consolidator.consolidateResults(someResults);
 
@@ -55,7 +58,7 @@ public class PassStatisticsResultsConsolidatorIT {
         LocalDate withinCutoffDate = someDate.plusDays(CUTOFF_DAYS - 1);
         AuditResult betterResultInRange = new AuditResult("any other correlation id", withinCutoffDate, someNino, AuditResultType.PASS);
 
-        Map<String, List<AuditResult>> someResults = ImmutableMap.of(someNino, Arrays.asList(worseResult, betterResultInRange));
+        List<List<AuditResult>> someResults = singletonList(asList(worseResult, betterResultInRange));
 
         List<AuditResult> consolidatedResult = consolidator.consolidateResults(someResults);
 
@@ -75,8 +78,8 @@ public class PassStatisticsResultsConsolidatorIT {
         AuditResult betterResult = new AuditResult("any correlation id", someDate, someOtherNino, AuditResultType.NOTFOUND);
         AuditResult worseResultInRange = new AuditResult("any correlation id", withinCutoffDate, someOtherNino, AuditResultType.ERROR);
 
-        Map<String, List<AuditResult>> someResults = ImmutableMap.of(someNino, Arrays.asList(worseResult, betterResultInRange),
-                                                                     someOtherNino, Arrays.asList(betterResult, worseResultInRange));
+        List<List<AuditResult>> someResults = asList(asList(worseResult, betterResultInRange),
+                                                     asList(betterResult, worseResult));
 
         List<AuditResult> consolidatedResult = consolidator.consolidateResults(someResults);
         assertThat(consolidatedResult).containsExactlyInAnyOrder(betterResult, betterResultInRange);
@@ -90,7 +93,7 @@ public class PassStatisticsResultsConsolidatorIT {
         AuditResult someResult = new AuditResult("any correlation id", SOME_DATE, someNino, AuditResultType.PASS);
         AuditResult resultAfterCutoffDate = new AuditResult("any correlation id", afterCutoffDate, someNino, AuditResultType.FAIL);
 
-        Map<String, List<AuditResult>> someResults = ImmutableMap.of(someNino, Arrays.asList(someResult, resultAfterCutoffDate));
+        List<List<AuditResult>> someResults = singletonList(asList(someResult, resultAfterCutoffDate));
 
         List<AuditResult> consolidatedResult = consolidator.consolidateResults(someResults);
         assertThat(consolidatedResult).containsExactlyInAnyOrder(someResult, resultAfterCutoffDate);
@@ -100,17 +103,13 @@ public class PassStatisticsResultsConsolidatorIT {
     public void consolidateResults_multipleNinosAndResults_splitWhenAfterCutoff() {
         List<AuditResult> shouldBePassAndFail = passAndAFail();
         List<AuditResult> shouldBeNotFoundAndError = notFoundAndAnError();
-        List<AuditResult> shouldBePass = Collections.singletonList(new AuditResult("any correlation id", SOME_DATE, "nino3", AuditResultType.PASS));
+        List<AuditResult> shouldBePass = singletonList(new AuditResult("any correlation id", SOME_DATE, "nino3", AuditResultType.PASS));
 
-        Map<String, List<AuditResult>> someResults = ImmutableMap.<String, List<AuditResult>>builder()
-            .put("nino1", shouldBePassAndFail)
-            .put("nino2", shouldBeNotFoundAndError)
-            .put("nino3", shouldBePass)
-            .build();
+        List<List<AuditResult>> someResults = asList(shouldBePassAndFail, shouldBeNotFoundAndError, shouldBePass);
 
-        List<AuditResult> expectedResults = Arrays.asList(shouldBePassAndFail.get(1), shouldBePassAndFail.get(2),
-                                                          shouldBeNotFoundAndError.get(0), shouldBeNotFoundAndError.get(1),
-                                                          shouldBePass.get(0));
+        List<AuditResult> expectedResults = asList(shouldBePassAndFail.get(1), shouldBePassAndFail.get(2),
+                                                   shouldBeNotFoundAndError.get(0), shouldBeNotFoundAndError.get(1),
+                                                   shouldBePass.get(0));
 
 
         List<AuditResult> actualResults = consolidator.consolidateResults(someResults);
@@ -122,7 +121,7 @@ public class PassStatisticsResultsConsolidatorIT {
         LocalDate date2 = withinCutoff(SOME_DATE);
         LocalDate date3 = afterCutoff(date2);
         LocalDate date4 = withinCutoff(date3);
-        return Arrays.asList(
+        return asList(
             new AuditResult("any correlation id", SOME_DATE, "nino1", AuditResultType.ERROR),
             new AuditResult("any correlation id", date2, "nino1", AuditResultType.PASS),
 
@@ -134,7 +133,7 @@ public class PassStatisticsResultsConsolidatorIT {
         LocalDate date2 = afterCutoff(SOME_DATE);
         LocalDate date3 = withinCutoff(date2);
 
-        return Arrays.asList(
+        return asList(
             new AuditResult("any correlation id", SOME_DATE, "nino2", AuditResultType.ERROR),
 
             new AuditResult("any correlation id", date2, "nino2", AuditResultType.NOTFOUND),

--- a/src/test/java/uk/gov/digital/ho/proving/income/audit/statistics/PassStatisticsResultsConsolidatorTest.java
+++ b/src/test/java/uk/gov/digital/ho/proving/income/audit/statistics/PassStatisticsResultsConsolidatorTest.java
@@ -48,7 +48,7 @@ public class PassStatisticsResultsConsolidatorTest {
     @Test
     public void consolidateResults_oneResult_returnResult() {
         AuditResult someAuditResult = new AuditResult("any correlation id", ANY_DATE, SOME_NINO, ANY_RESULT);
-        List<AuditResult> singleResult = singletonList(someAuditResult);
+        AuditResultsGroupedByNino singleResult = new AuditResultsGroupedByNino(someAuditResult);
 
         List<AuditResult> consolidatedResult = statisticsResultsConsolidator.consolidateResults(singletonList(singleResult));
 
@@ -60,8 +60,8 @@ public class PassStatisticsResultsConsolidatorTest {
         AuditResult someAuditResult = new AuditResult("any correlation id", ANY_DATE, SOME_NINO, AuditResultType.PASS);
         AuditResult someOtherAuditResult = new AuditResult("any other correlation id", ANY_DATE, SOME_OTHER_NINO, AuditResultType.FAIL);
 
-        List<List<AuditResult>> someResultsGroupedByNino = Arrays.asList(singletonList(someAuditResult),
-                                                                         singletonList(someOtherAuditResult));
+        List<AuditResultsGroupedByNino> someResultsGroupedByNino = Arrays.asList(new AuditResultsGroupedByNino(someAuditResult),
+                                                                                 new AuditResultsGroupedByNino(someOtherAuditResult));
 
         List<AuditResult> consolidatedResult = statisticsResultsConsolidator.consolidateResults(someResultsGroupedByNino);
 

--- a/src/test/java/uk/gov/digital/ho/proving/income/audit/statistics/PassStatisticsResultsConsolidatorTest.java
+++ b/src/test/java/uk/gov/digital/ho/proving/income/audit/statistics/PassStatisticsResultsConsolidatorTest.java
@@ -1,6 +1,5 @@
 package uk.gov.digital.ho.proving.income.audit.statistics;
 
-import com.google.common.collect.ImmutableMap;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -14,7 +13,6 @@ import java.time.LocalDate;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
-import java.util.Map;
 
 import static java.util.Collections.emptyList;
 import static java.util.Collections.singletonList;

--- a/src/test/java/uk/gov/digital/ho/proving/income/audit/statistics/PassStatisticsResultsConsolidatorTest.java
+++ b/src/test/java/uk/gov/digital/ho/proving/income/audit/statistics/PassStatisticsResultsConsolidatorTest.java
@@ -87,9 +87,9 @@ public class PassStatisticsResultsConsolidatorTest {
         results.add(new AuditResult("any correlation id", date2, SOME_NINO, ANY_RESULT));
         results.add(new AuditResult("any correlation id", date3, SOME_NINO, ANY_RESULT));
 
-        AuditResultsGroupedByNino expectedResult1 = new AuditResultsGroupedByNino(results.results().get(0));
-        expectedResult1.add(results.results().get(1));
-        AuditResultsGroupedByNino expectedResult2 = new AuditResultsGroupedByNino(results.results().get(2));
+        AuditResultsGroupedByNino expectedResult1 = new AuditResultsGroupedByNino(results.get(0));
+        expectedResult1.add(results.get(1));
+        AuditResultsGroupedByNino expectedResult2 = new AuditResultsGroupedByNino(results.get(2));
         assertThat(statisticsResultsConsolidator.separateResultsByCutoff(results))
             .containsExactlyInAnyOrder(expectedResult1, expectedResult2);
     }
@@ -103,9 +103,9 @@ public class PassStatisticsResultsConsolidatorTest {
         results.add(new AuditResult("any correlation id", date2, SOME_NINO, ANY_RESULT));
         results.add(new AuditResult("any correlation id", date3, SOME_NINO, ANY_RESULT));
 
-        AuditResultsGroupedByNino expectedResult1 = new AuditResultsGroupedByNino(results.results().get(0));
-        AuditResultsGroupedByNino expectedResult2 = new AuditResultsGroupedByNino(results.results().get(1));
-        expectedResult2.add(results.results().get(2));
+        AuditResultsGroupedByNino expectedResult1 = new AuditResultsGroupedByNino(results.get(0));
+        AuditResultsGroupedByNino expectedResult2 = new AuditResultsGroupedByNino(results.get(1));
+        expectedResult2.add(results.get(2));
 
         assertThat(statisticsResultsConsolidator.separateResultsByCutoff(results))
             .containsExactlyInAnyOrder(expectedResult1, expectedResult2);
@@ -120,9 +120,9 @@ public class PassStatisticsResultsConsolidatorTest {
         results.add(new AuditResult("any correlation id", date2, SOME_NINO, ANY_RESULT));
         results.add(new AuditResult("any correlation id", date3, SOME_NINO, ANY_RESULT));
 
-        AuditResultsGroupedByNino expectedResult1 = new AuditResultsGroupedByNino(results.results().get(0));
-        AuditResultsGroupedByNino expectedResult2 = new AuditResultsGroupedByNino(results.results().get(1));
-        AuditResultsGroupedByNino expectedResult3 = new AuditResultsGroupedByNino(results.results().get(2));
+        AuditResultsGroupedByNino expectedResult1 = new AuditResultsGroupedByNino(results.get(0));
+        AuditResultsGroupedByNino expectedResult2 = new AuditResultsGroupedByNino(results.get(1));
+        AuditResultsGroupedByNino expectedResult3 = new AuditResultsGroupedByNino(results.get(2));
         assertThat(statisticsResultsConsolidator.separateResultsByCutoff(results))
             .containsExactlyInAnyOrder(expectedResult1, expectedResult2, expectedResult3);
     }

--- a/src/test/java/uk/gov/digital/ho/proving/income/audit/statistics/PassStatisticsResultsConsolidatorTest.java
+++ b/src/test/java/uk/gov/digital/ho/proving/income/audit/statistics/PassStatisticsResultsConsolidatorTest.java
@@ -1,0 +1,144 @@
+package uk.gov.digital.ho.proving.income.audit.statistics;
+
+import com.google.common.collect.ImmutableMap;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+import uk.gov.digital.ho.proving.income.audit.AuditResult;
+import uk.gov.digital.ho.proving.income.audit.AuditResultComparator;
+import uk.gov.digital.ho.proving.income.audit.AuditResultType;
+
+import java.time.LocalDate;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+
+import static java.util.Collections.emptyList;
+import static java.util.Collections.singletonList;
+import static org.assertj.core.api.Assertions.assertThat;
+
+@RunWith(MockitoJUnitRunner.class)
+public class PassStatisticsResultsConsolidatorTest {
+
+    private static final int CUTOFF_DAYS = 10;
+
+    private static final AuditResultType ANY_RESULT = AuditResultType.PASS;
+    private static final LocalDate ANY_DATE = LocalDate.now();
+    private static final String SOME_NINO = "AA112233A";
+    private static final String SOME_OTHER_NINO = "BB112233A";
+
+    @Mock
+    private AuditResultComparator mockResultsComparator;
+
+    private PassStatisticsResultsConsolidator statisticsResultsConsolidator;
+    private static final LocalDate SOME_DATE = LocalDate.now();
+
+    @Before
+    public void setUp() {
+        statisticsResultsConsolidator = new PassStatisticsResultsConsolidator(mockResultsComparator, CUTOFF_DAYS);
+    }
+
+    @Test
+    public void consolidateResults_emptyMap_returnEmptyList() {
+        assertThat(statisticsResultsConsolidator.consolidateResults(Collections.emptyMap()))
+            .isEmpty();
+    }
+
+    @Test
+    public void consolidateResults_oneResult_returnResult() {
+        AuditResult someAuditResult = new AuditResult("any correlation id", ANY_DATE, SOME_NINO, ANY_RESULT);
+
+        Map<String, List<AuditResult>> someResults = ImmutableMap.of(SOME_NINO, singletonList(someAuditResult));
+
+        List<AuditResult> consolidatedResult = statisticsResultsConsolidator.consolidateResults(someResults);
+
+        assertThat(consolidatedResult).containsExactlyInAnyOrder(someAuditResult);
+    }
+
+    @Test
+    public void consolidateResults_twoNinos_oneResultEach_returnResults() {
+        AuditResult someAuditResult = new AuditResult("any correlation id", ANY_DATE, SOME_NINO, AuditResultType.PASS);
+        AuditResult someOtherAuditResult = new AuditResult("any other correlation id", ANY_DATE, SOME_OTHER_NINO, AuditResultType.FAIL);
+
+        Map<String, List<AuditResult>> someResults = ImmutableMap.of(SOME_NINO, singletonList(someAuditResult),
+                                                                     SOME_OTHER_NINO, singletonList(someOtherAuditResult));
+
+        List<AuditResult> consolidatedResult = statisticsResultsConsolidator.consolidateResults(someResults);
+
+        assertThat(consolidatedResult).containsExactlyInAnyOrder(someAuditResult, someOtherAuditResult);
+    }
+
+    @Test
+    public void separateResultsByCutoff_noResults_emptyList() {
+        assertThat(statisticsResultsConsolidator.separateResultsByCutoff(emptyList()))
+            .isEqualTo(emptyList());
+    }
+
+    @Test
+    public void separateResultsByCutoff_oneResult_returnResult() {
+        List<AuditResult> singleResult = singletonList(new AuditResult("any correlation id", ANY_DATE, SOME_NINO, ANY_RESULT));
+
+        assertThat(statisticsResultsConsolidator.separateResultsByCutoff(singleResult))
+            .isEqualTo(singletonList(singleResult));
+    }
+
+    @Test
+    public void separateResultsByCutoff_threeResults_gapBetweenSecondAndThird_groupFirstTwo() {
+        LocalDate date2 = withinCutoff(SOME_DATE);
+        LocalDate date3 = afterCutoff(date2);
+        List<AuditResult> results = Arrays.asList(new AuditResult("any correlation id", SOME_DATE, SOME_NINO, ANY_RESULT),
+                                                  new AuditResult("any correlation id", date2, SOME_NINO, ANY_RESULT),
+                                                  new AuditResult("any correlation id", date3, SOME_NINO, ANY_RESULT));
+
+        assertThat(statisticsResultsConsolidator.separateResultsByCutoff(results))
+            .containsExactlyInAnyOrder(Arrays.asList(results.get(0), results.get(1)), singletonList(results.get(2)));
+    }
+
+    @Test
+    public void separateResultsByCutoff_threeResults_gapBetweenFirstAndSecond_groupLastTwo() {
+        LocalDate date2 = afterCutoff(SOME_DATE);
+        LocalDate date3 = withinCutoff(date2);
+        List<AuditResult> results = Arrays.asList(new AuditResult("any correlation id", SOME_DATE, SOME_NINO, ANY_RESULT),
+                                                  new AuditResult("any correlation id", date2, SOME_NINO, ANY_RESULT),
+                                                  new AuditResult("any correlation id", date3, SOME_NINO, ANY_RESULT));
+
+        assertThat(statisticsResultsConsolidator.separateResultsByCutoff(results))
+            .containsExactlyInAnyOrder(singletonList(results.get(0)), Arrays.asList(results.get(1), results.get(2)));
+
+    }
+
+    @Test
+    public void separateResultsByCutoff_threeResults_gapBetweenEach_noGrouping() {
+        LocalDate date2 = afterCutoff(SOME_DATE);
+        LocalDate date3 = afterCutoff(date2);
+        List<AuditResult> results = Arrays.asList(new AuditResult("any correlation id", SOME_DATE, SOME_NINO, ANY_RESULT),
+                                                  new AuditResult("any correlation id", date2, SOME_NINO, ANY_RESULT),
+                                                  new AuditResult("any correlation id", date3, SOME_NINO, ANY_RESULT));
+
+        assertThat(statisticsResultsConsolidator.separateResultsByCutoff(results))
+            .containsExactlyInAnyOrder(singletonList(results.get(0)), singletonList(results.get(1)), singletonList(results.get(2)));
+    }
+
+    @Test
+    public void separateResultsByCutoff_threeResults_noGaps_groupAll() {
+        LocalDate date2 = withinCutoff(SOME_DATE);
+        LocalDate date3 = withinCutoff(date2);
+        List<AuditResult> results = Arrays.asList(new AuditResult("any correlation id", SOME_DATE, SOME_NINO, ANY_RESULT),
+                                                  new AuditResult("any correlation id", date2, SOME_NINO, ANY_RESULT),
+                                                  new AuditResult("any correlation id", date3, SOME_NINO, ANY_RESULT));
+
+        assertThat(statisticsResultsConsolidator.separateResultsByCutoff(results))
+            .containsExactlyInAnyOrder(results);
+    }
+
+    private LocalDate withinCutoff(LocalDate date) {
+        return date.plusDays(CUTOFF_DAYS - 1);
+    }
+
+    private LocalDate afterCutoff(LocalDate date) {
+        return date.plusDays(CUTOFF_DAYS);
+    }
+}

--- a/src/test/java/uk/gov/digital/ho/proving/income/audit/statistics/PassStatisticsResultsConsolidatorTest.java
+++ b/src/test/java/uk/gov/digital/ho/proving/income/audit/statistics/PassStatisticsResultsConsolidatorTest.java
@@ -72,8 +72,10 @@ public class PassStatisticsResultsConsolidatorTest {
     public void separateResultsByCutoff_oneResult_returnResult() {
         AuditResultsGroupedByNino singleResult = new AuditResultsGroupedByNino(new AuditResult("any correlation id", ANY_DATE, SOME_NINO, ANY_RESULT));
 
-        assertThat(statisticsResultsConsolidator.separateResultsByCutoff(singleResult))
-            .isEqualTo(singletonList(singletonList(singleResult.results().get(0))));
+        List<AuditResultsGroupedByNino> separatedResults = statisticsResultsConsolidator.separateResultsByCutoff(singleResult);
+        assertThat(separatedResults).hasSize(1);
+
+        assertThat(separatedResults.get(0)).isEqualTo(singleResult);
     }
 
     @Test
@@ -85,8 +87,11 @@ public class PassStatisticsResultsConsolidatorTest {
         results.add(new AuditResult("any correlation id", date2, SOME_NINO, ANY_RESULT));
         results.add(new AuditResult("any correlation id", date3, SOME_NINO, ANY_RESULT));
 
+        AuditResultsGroupedByNino expectedResult1 = new AuditResultsGroupedByNino(results.results().get(0));
+        expectedResult1.add(results.results().get(1));
+        AuditResultsGroupedByNino expectedResult2 = new AuditResultsGroupedByNino(results.results().get(2));
         assertThat(statisticsResultsConsolidator.separateResultsByCutoff(results))
-            .containsExactlyInAnyOrder(Arrays.asList(results.results().get(0), results.results().get(1)), singletonList(results.results().get(2)));
+            .containsExactlyInAnyOrder(expectedResult1, expectedResult2);
     }
 
     @Test
@@ -98,8 +103,12 @@ public class PassStatisticsResultsConsolidatorTest {
         results.add(new AuditResult("any correlation id", date2, SOME_NINO, ANY_RESULT));
         results.add(new AuditResult("any correlation id", date3, SOME_NINO, ANY_RESULT));
 
+        AuditResultsGroupedByNino expectedResult1 = new AuditResultsGroupedByNino(results.results().get(0));
+        AuditResultsGroupedByNino expectedResult2 = new AuditResultsGroupedByNino(results.results().get(1));
+        expectedResult2.add(results.results().get(2));
+
         assertThat(statisticsResultsConsolidator.separateResultsByCutoff(results))
-            .containsExactlyInAnyOrder(singletonList(results.results().get(0)), Arrays.asList(results.results().get(1), results.results().get(2)));
+            .containsExactlyInAnyOrder(expectedResult1, expectedResult2);
 
     }
 
@@ -111,8 +120,11 @@ public class PassStatisticsResultsConsolidatorTest {
         results.add(new AuditResult("any correlation id", date2, SOME_NINO, ANY_RESULT));
         results.add(new AuditResult("any correlation id", date3, SOME_NINO, ANY_RESULT));
 
+        AuditResultsGroupedByNino expectedResult1 = new AuditResultsGroupedByNino(results.results().get(0));
+        AuditResultsGroupedByNino expectedResult2 = new AuditResultsGroupedByNino(results.results().get(1));
+        AuditResultsGroupedByNino expectedResult3 = new AuditResultsGroupedByNino(results.results().get(2));
         assertThat(statisticsResultsConsolidator.separateResultsByCutoff(results))
-            .containsExactlyInAnyOrder(singletonList(results.results().get(0)), singletonList(results.results().get(1)), singletonList(results.results().get(2)));
+            .containsExactlyInAnyOrder(expectedResult1, expectedResult2, expectedResult3);
     }
 
     @Test
@@ -123,8 +135,8 @@ public class PassStatisticsResultsConsolidatorTest {
         results.add(new AuditResult("any correlation id", date2, SOME_NINO, ANY_RESULT));
         results.add(new AuditResult("any correlation id", date3, SOME_NINO, ANY_RESULT));
 
-        assertThat(statisticsResultsConsolidator.separateResultsByCutoff(results))
-            .containsExactlyInAnyOrder(results.results());
+        List<AuditResultsGroupedByNino> separatedResults = statisticsResultsConsolidator.separateResultsByCutoff(results);
+        assertThat(separatedResults).containsExactly(results);
     }
 
     private LocalDate withinCutoff(LocalDate date) {

--- a/src/test/java/uk/gov/digital/ho/proving/income/audit/statistics/PassStatisticsResultsConsolidatorTest.java
+++ b/src/test/java/uk/gov/digital/ho/proving/income/audit/statistics/PassStatisticsResultsConsolidatorTest.java
@@ -140,10 +140,10 @@ public class PassStatisticsResultsConsolidatorTest {
     }
 
     private LocalDate withinCutoff(LocalDate date) {
-        return date.plusDays(CUTOFF_DAYS - 1);
+        return date.plusDays(CUTOFF_DAYS);
     }
 
     private LocalDate afterCutoff(LocalDate date) {
-        return date.plusDays(CUTOFF_DAYS);
+        return date.plusDays(CUTOFF_DAYS + 1);
     }
 }

--- a/src/test/java/uk/gov/digital/ho/proving/income/audit/statistics/PassStatisticsResultsConsolidatorTest.java
+++ b/src/test/java/uk/gov/digital/ho/proving/income/audit/statistics/PassStatisticsResultsConsolidatorTest.java
@@ -69,41 +69,37 @@ public class PassStatisticsResultsConsolidatorTest {
     }
 
     @Test
-    public void separateResultsByCutoff_noResults_emptyList() {
-        assertThat(statisticsResultsConsolidator.separateResultsByCutoff(emptyList()))
-            .isEqualTo(emptyList());
-    }
-
-    @Test
     public void separateResultsByCutoff_oneResult_returnResult() {
-        List<AuditResult> singleResult = singletonList(new AuditResult("any correlation id", ANY_DATE, SOME_NINO, ANY_RESULT));
+        AuditResultsGroupedByNino singleResult = new AuditResultsGroupedByNino(new AuditResult("any correlation id", ANY_DATE, SOME_NINO, ANY_RESULT));
 
         assertThat(statisticsResultsConsolidator.separateResultsByCutoff(singleResult))
-            .isEqualTo(singletonList(singleResult));
+            .isEqualTo(singletonList(singletonList(singleResult.results().get(0))));
     }
 
     @Test
     public void separateResultsByCutoff_threeResults_gapBetweenSecondAndThird_groupFirstTwo() {
         LocalDate date2 = withinCutoff(SOME_DATE);
         LocalDate date3 = afterCutoff(date2);
-        List<AuditResult> results = Arrays.asList(new AuditResult("any correlation id", SOME_DATE, SOME_NINO, ANY_RESULT),
-                                                  new AuditResult("any correlation id", date2, SOME_NINO, ANY_RESULT),
-                                                  new AuditResult("any correlation id", date3, SOME_NINO, ANY_RESULT));
+
+        AuditResultsGroupedByNino results = new AuditResultsGroupedByNino(new AuditResult("any correlation id", SOME_DATE, SOME_NINO, ANY_RESULT));
+        results.add(new AuditResult("any correlation id", date2, SOME_NINO, ANY_RESULT));
+        results.add(new AuditResult("any correlation id", date3, SOME_NINO, ANY_RESULT));
 
         assertThat(statisticsResultsConsolidator.separateResultsByCutoff(results))
-            .containsExactlyInAnyOrder(Arrays.asList(results.get(0), results.get(1)), singletonList(results.get(2)));
+            .containsExactlyInAnyOrder(Arrays.asList(results.results().get(0), results.results().get(1)), singletonList(results.results().get(2)));
     }
 
     @Test
     public void separateResultsByCutoff_threeResults_gapBetweenFirstAndSecond_groupLastTwo() {
         LocalDate date2 = afterCutoff(SOME_DATE);
         LocalDate date3 = withinCutoff(date2);
-        List<AuditResult> results = Arrays.asList(new AuditResult("any correlation id", SOME_DATE, SOME_NINO, ANY_RESULT),
-                                                  new AuditResult("any correlation id", date2, SOME_NINO, ANY_RESULT),
-                                                  new AuditResult("any correlation id", date3, SOME_NINO, ANY_RESULT));
+
+        AuditResultsGroupedByNino results = new AuditResultsGroupedByNino(new AuditResult("any correlation id", SOME_DATE, SOME_NINO, ANY_RESULT));
+        results.add(new AuditResult("any correlation id", date2, SOME_NINO, ANY_RESULT));
+        results.add(new AuditResult("any correlation id", date3, SOME_NINO, ANY_RESULT));
 
         assertThat(statisticsResultsConsolidator.separateResultsByCutoff(results))
-            .containsExactlyInAnyOrder(singletonList(results.get(0)), Arrays.asList(results.get(1), results.get(2)));
+            .containsExactlyInAnyOrder(singletonList(results.results().get(0)), Arrays.asList(results.results().get(1), results.results().get(2)));
 
     }
 
@@ -111,24 +107,24 @@ public class PassStatisticsResultsConsolidatorTest {
     public void separateResultsByCutoff_threeResults_gapBetweenEach_noGrouping() {
         LocalDate date2 = afterCutoff(SOME_DATE);
         LocalDate date3 = afterCutoff(date2);
-        List<AuditResult> results = Arrays.asList(new AuditResult("any correlation id", SOME_DATE, SOME_NINO, ANY_RESULT),
-                                                  new AuditResult("any correlation id", date2, SOME_NINO, ANY_RESULT),
-                                                  new AuditResult("any correlation id", date3, SOME_NINO, ANY_RESULT));
+        AuditResultsGroupedByNino results = new AuditResultsGroupedByNino(new AuditResult("any correlation id", SOME_DATE, SOME_NINO, ANY_RESULT));
+        results.add(new AuditResult("any correlation id", date2, SOME_NINO, ANY_RESULT));
+        results.add(new AuditResult("any correlation id", date3, SOME_NINO, ANY_RESULT));
 
         assertThat(statisticsResultsConsolidator.separateResultsByCutoff(results))
-            .containsExactlyInAnyOrder(singletonList(results.get(0)), singletonList(results.get(1)), singletonList(results.get(2)));
+            .containsExactlyInAnyOrder(singletonList(results.results().get(0)), singletonList(results.results().get(1)), singletonList(results.results().get(2)));
     }
 
     @Test
     public void separateResultsByCutoff_threeResults_noGaps_groupAll() {
         LocalDate date2 = withinCutoff(SOME_DATE);
         LocalDate date3 = withinCutoff(date2);
-        List<AuditResult> results = Arrays.asList(new AuditResult("any correlation id", SOME_DATE, SOME_NINO, ANY_RESULT),
-                                                  new AuditResult("any correlation id", date2, SOME_NINO, ANY_RESULT),
-                                                  new AuditResult("any correlation id", date3, SOME_NINO, ANY_RESULT));
+        AuditResultsGroupedByNino results = new AuditResultsGroupedByNino(new AuditResult("any correlation id", SOME_DATE, SOME_NINO, ANY_RESULT));
+        results.add(new AuditResult("any correlation id", date2, SOME_NINO, ANY_RESULT));
+        results.add(new AuditResult("any correlation id", date3, SOME_NINO, ANY_RESULT));
 
         assertThat(statisticsResultsConsolidator.separateResultsByCutoff(results))
-            .containsExactlyInAnyOrder(results);
+            .containsExactlyInAnyOrder(results.results());
     }
 
     private LocalDate withinCutoff(LocalDate date) {

--- a/src/test/java/uk/gov/digital/ho/proving/income/audit/statistics/PassStatisticsResultsConsolidatorTest.java
+++ b/src/test/java/uk/gov/digital/ho/proving/income/audit/statistics/PassStatisticsResultsConsolidatorTest.java
@@ -42,18 +42,17 @@ public class PassStatisticsResultsConsolidatorTest {
     }
 
     @Test
-    public void consolidateResults_emptyMap_returnEmptyList() {
-        assertThat(statisticsResultsConsolidator.consolidateResults(Collections.emptyMap()))
+    public void consolidateResults_emptyList_returnEmptyList() {
+        assertThat(statisticsResultsConsolidator.consolidateResults(Collections.emptyList()))
             .isEmpty();
     }
 
     @Test
     public void consolidateResults_oneResult_returnResult() {
         AuditResult someAuditResult = new AuditResult("any correlation id", ANY_DATE, SOME_NINO, ANY_RESULT);
+        List<AuditResult> singleResult = singletonList(someAuditResult);
 
-        Map<String, List<AuditResult>> someResults = ImmutableMap.of(SOME_NINO, singletonList(someAuditResult));
-
-        List<AuditResult> consolidatedResult = statisticsResultsConsolidator.consolidateResults(someResults);
+        List<AuditResult> consolidatedResult = statisticsResultsConsolidator.consolidateResults(singletonList(singleResult));
 
         assertThat(consolidatedResult).containsExactlyInAnyOrder(someAuditResult);
     }
@@ -63,10 +62,10 @@ public class PassStatisticsResultsConsolidatorTest {
         AuditResult someAuditResult = new AuditResult("any correlation id", ANY_DATE, SOME_NINO, AuditResultType.PASS);
         AuditResult someOtherAuditResult = new AuditResult("any other correlation id", ANY_DATE, SOME_OTHER_NINO, AuditResultType.FAIL);
 
-        Map<String, List<AuditResult>> someResults = ImmutableMap.of(SOME_NINO, singletonList(someAuditResult),
-                                                                     SOME_OTHER_NINO, singletonList(someOtherAuditResult));
+        List<List<AuditResult>> someResultsGroupedByNino = Arrays.asList(singletonList(someAuditResult),
+                                                                         singletonList(someOtherAuditResult));
 
-        List<AuditResult> consolidatedResult = statisticsResultsConsolidator.consolidateResults(someResults);
+        List<AuditResult> consolidatedResult = statisticsResultsConsolidator.consolidateResults(someResultsGroupedByNino);
 
         assertThat(consolidatedResult).containsExactlyInAnyOrder(someAuditResult, someOtherAuditResult);
     }


### PR DESCRIPTION
Added PassStatisticsResultsConsolidator which takes a List of AuditResults grouped by Nino (hence List<List<AuditResult>>) and returns a List<AuditResult> of the best results per Nino.

Unlike the current Statistics calculation, if a request happens 10 days (configurable) after the last one for that Nino, it is not considered to be the same request so you could have multiple results for a single Nino.

I have added a TODO with a commented semi-pseudo code implementation of how I think Statistics will now be calculated to give a clue as to how this class will be used.

As the new code is not attached to anything I intend to merge once approved.