### PR TITLE
Ee 21001 split statistics service, part 1

### DIFF
--- a/config/checkstyle/checkstyle.xml
+++ b/config/checkstyle/checkstyle.xml
@@ -115,4 +115,5 @@
         <property name="max" value="1000"/>
     </module>
     <module name="StrictDuplicateCode"/>
+    <module name="SuppressionCommentFilter"/><!--TODO EE-21001 Temporarily duplicating code which requires the supression, remove when refactoring complete -->
 </module>

--- a/src/main/java/uk/gov/digital/ho/proving/income/audit/statistics/AuditResultFetcher.java
+++ b/src/main/java/uk/gov/digital/ho/proving/income/audit/statistics/AuditResultFetcher.java
@@ -1,0 +1,67 @@
+package uk.gov.digital.ho.proving.income.audit.statistics;
+
+import org.springframework.stereotype.Component;
+import uk.gov.digital.ho.proving.income.audit.*;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import static uk.gov.digital.ho.proving.income.audit.statistics.PassRateStatisticsService.AUDIT_EVENTS_TO_RETRIEVE;
+
+@Component
+public class AuditResultFetcher {
+
+    private final AuditClient auditClient;
+    private final AuditResultConsolidator resultConsolidator;
+    private final AuditResultComparator resultComparator;
+
+    public AuditResultFetcher(AuditClient auditClient, AuditResultConsolidator resultConsolidator,  AuditResultComparator resultComparator) {
+        this.auditClient = auditClient;
+        this.resultConsolidator = resultConsolidator;
+        this.resultComparator = resultComparator;
+    }
+
+    public List<AuditResult> getAuditResults(List<String> correlationIds) {
+        Map<String, AuditResult> bestResultsByNino = new HashMap<>();
+        for (String correlationId : correlationIds) {
+            AuditResult auditResult = getAuditResultForCorrelationId(correlationId);
+            updateBestResults(bestResultsByNino, auditResult);
+        }
+        return new ArrayList<>(bestResultsByNino.values());
+//
+//        // TODO EE-21001 - probable new routine:
+//        // Build up a map where each nino is the key and all the query results for that nino are stored in a list as the value
+//        // Map<String, AuditResultsGroupedByNino> resultsByNino = new HashMap<>();
+//        // for (String correlationId : allCorrelationIds) {
+//        // AuditResult auditResult = getAuditResultForCorrelationId(correlationId);
+//        //     if(!resultsByNino.hasKey(auditResult.nino()) {
+//        //         resultByNino.put(auditResult.nino(), AuditResultsGroupedByNino(auditResult)));
+//        //     } else {
+//        //         resultByNino.get(auditResult.nino()).add(auditResult)
+//        //     }
+//        // }
+//        //
+//        // Consolidate the results into a single list - for each nino, sort results by date, split list if any 10 day gaps,
+//        // for each split list of results - calculate best earliest result and put into the final results list.
+//        // return PassRateStatisticsConsolidator.consolidateResults(resultByNino.values())
+    }
+
+    private AuditResult getAuditResultForCorrelationId(String correlationId) {
+        List<AuditRecord> auditRecordsForCorrelationId = auditClient.getHistoryByCorrelationId(correlationId, AUDIT_EVENTS_TO_RETRIEVE);
+        return resultConsolidator.getAuditResult(auditRecordsForCorrelationId);
+    }
+
+    private void updateBestResults(Map<String, AuditResult> bestResultsByNino, AuditResult newResult) {
+        String nino = newResult.nino();
+
+        if (!bestResultsByNino.containsKey(nino) || isBetterResult(bestResultsByNino.get(nino), newResult)) {
+            bestResultsByNino.put(nino, newResult);
+        }
+    }
+
+    private boolean isBetterResult(AuditResult currentResult, AuditResult newResult) {
+        return resultComparator.compare(currentResult, newResult) < 0;
+    }
+}

--- a/src/main/java/uk/gov/digital/ho/proving/income/audit/statistics/PassRateStatisticsService.java
+++ b/src/main/java/uk/gov/digital/ho/proving/income/audit/statistics/PassRateStatisticsService.java
@@ -17,6 +17,7 @@ import static uk.gov.digital.ho.proving.income.audit.AuditEventType.INCOME_PROVI
 import static uk.gov.digital.ho.proving.income.audit.AuditEventType.INCOME_PROVING_FINANCIAL_STATUS_RESPONSE;
 
 @Component
+//Checksty
 public class PassRateStatisticsService {
 
     static final List<AuditEventType> AUDIT_EVENTS_TO_RETRIEVE = asList(
@@ -49,6 +50,7 @@ public class PassRateStatisticsService {
         return generatePassRateStatistics(taxYear.startDate(), taxYear.endDate());
     }
 
+
     public PassRateStatistics generatePassRateStatistics(LocalDate fromDate, LocalDate toDate) {
         LocalDate cutOffDate = toDate.plusDays(cutoffDays);
         List<String> allCorrelationIds = auditClient.getAllCorrelationIdsForEventType(AUDIT_EVENTS_TO_RETRIEVE, cutOffDate);
@@ -74,6 +76,8 @@ public class PassRateStatisticsService {
         return consolidator.getAuditResult(auditRecordsForCorrelationId);
     }
 
+    //CHECKSTYLE:OFF
+    // TODO EE-21001 Temporarily duplicated in AuditResultFetcher as part of refactor
     private void updateBestResults(Map<String, AuditResult> bestResultsByNino, AuditResult newResult) {
         String nino = newResult.nino();
 
@@ -85,4 +89,5 @@ public class PassRateStatisticsService {
     private boolean isBetterResult(AuditResult currentResult, AuditResult newResult) {
         return resultComparator.compare(currentResult, newResult) < 0;
     }
+    //CHECKSTYLE:ON
 }

--- a/src/main/java/uk/gov/digital/ho/proving/income/audit/statistics/PassRateStatisticsService.java
+++ b/src/main/java/uk/gov/digital/ho/proving/income/audit/statistics/PassRateStatisticsService.java
@@ -17,7 +17,6 @@ import static uk.gov.digital.ho.proving.income.audit.AuditEventType.INCOME_PROVI
 import static uk.gov.digital.ho.proving.income.audit.AuditEventType.INCOME_PROVING_FINANCIAL_STATUS_RESPONSE;
 
 @Component
-//Checksty
 public class PassRateStatisticsService {
 
     static final List<AuditEventType> AUDIT_EVENTS_TO_RETRIEVE = asList(

--- a/src/main/java/uk/gov/digital/ho/proving/income/audit/statistics/PassRateStatisticsService.java
+++ b/src/main/java/uk/gov/digital/ho/proving/income/audit/statistics/PassRateStatisticsService.java
@@ -19,7 +19,7 @@ import static uk.gov.digital.ho.proving.income.audit.AuditEventType.INCOME_PROVI
 @Component
 public class PassRateStatisticsService {
 
-    private static final List<AuditEventType> AUDIT_EVENTS_TO_RETRIEVE = asList(
+    static final List<AuditEventType> AUDIT_EVENTS_TO_RETRIEVE = asList(
         INCOME_PROVING_FINANCIAL_STATUS_REQUEST,
         INCOME_PROVING_FINANCIAL_STATUS_RESPONSE
     );
@@ -60,28 +60,13 @@ public class PassRateStatisticsService {
     }
 
     private List<AuditResult> getAuditResults(List<String> allCorrelationIds) {
+        // TODO EE-21001 - This is being migrated AuditResultFetcher
         Map<String, AuditResult> bestResultsByNino = new HashMap<>();
         for (String correlationId : allCorrelationIds) {
             AuditResult auditResult = getAuditResultForCorrelationId(correlationId);
             updateBestResults(bestResultsByNino, auditResult);
         }
         return new ArrayList<>(bestResultsByNino.values());
-
-        // TODO EE-21001 - probable new routine:
-        // Build up a map where each nino is the key and all the query results for that nino are stored in a list as the value
-        // Map<String, AuditResultsGroupedByNino> resultsByNino = new HashMap<>();
-        // for (String correlationId : allCorrelationIds) {
-        // AuditResult auditResult = getAuditResultForCorrelationId(correlationId);
-        //     if(!resultsByNino.hasKey(auditResult.nino()) {
-        //         resultByNino.put(auditResult.nino(), AuditResultsGroupedByNino(auditResult)));
-        //     } else {
-        //         resultByNino.get(auditResult.nino()).add(auditResult)
-        //     }
-        // }
-        //
-        // Consolidate the results into a single list - for each nino, sort results by date, split list if any 10 day gaps,
-        // for each split list of results - calculate best earliest result and put into the final results list.
-        // return PassRateStatisticsConsolidator.consolidateResults(resultByNino.values())
     }
 
     private AuditResult getAuditResultForCorrelationId(String correlationId) {

--- a/src/test/java/uk/gov/digital/ho/proving/income/audit/statistics/AuditResultFetcherTest.java
+++ b/src/test/java/uk/gov/digital/ho/proving/income/audit/statistics/AuditResultFetcherTest.java
@@ -1,0 +1,115 @@
+package uk.gov.digital.ho.proving.income.audit.statistics;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import org.apache.commons.lang3.ArrayUtils;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+import uk.gov.digital.ho.proving.income.audit.*;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.Arrays;
+import java.util.List;
+
+import static java.util.Arrays.asList;
+import static java.util.Collections.singletonList;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.BDDMockito.*;
+import static org.mockito.Mockito.when;
+import static uk.gov.digital.ho.proving.income.audit.AuditEventType.INCOME_PROVING_FINANCIAL_STATUS_REQUEST;
+import static uk.gov.digital.ho.proving.income.audit.AuditEventType.INCOME_PROVING_FINANCIAL_STATUS_RESPONSE;
+
+@RunWith(MockitoJUnitRunner.class)
+public class AuditResultFetcherTest {
+
+    private static final LocalDate ANY_DATE = LocalDate.now();
+    private static final LocalDateTime ANY_DATE_TIME = LocalDateTime.now();
+    private static final AuditEventType ANY_AUDIT_EVENT_TYPE = INCOME_PROVING_FINANCIAL_STATUS_REQUEST;
+    private static final JsonNode ANY_JSON = null;
+    private static final AuditResultType ANY_AUDIT_RESULT_TYPE = AuditResultType.PASS;
+    private static final AuditResult ANY_AUDIT_RECORD = new AuditResult("any correlation id", ANY_DATE, "any nino", ANY_AUDIT_RESULT_TYPE);
+
+    @Mock
+    private AuditResultConsolidator mockConsolidator;
+    @Mock
+    private AuditClient mockAuditClient;
+    @Mock
+    private AuditResultComparator mockComparator;
+
+    private AuditResultFetcher auditResultFetcher;
+
+    @Before
+    public void setUp() {
+        auditResultFetcher = new AuditResultFetcher(mockAuditClient, mockConsolidator, mockComparator);
+    }
+
+    @Test
+    public void getAuditResults_someCorrelationIds_callGetByCorrelationIdWithEachInTurn() {
+
+        given(mockConsolidator.getAuditResult(any())).willReturn(ANY_AUDIT_RECORD);
+
+        List<AuditEventType> expectedEventTypes = asList(INCOME_PROVING_FINANCIAL_STATUS_REQUEST, INCOME_PROVING_FINANCIAL_STATUS_RESPONSE);
+        ArgumentCaptor<String> correlationIdCaptor = ArgumentCaptor.forClass(String.class);
+
+        List<String> someCorrelationIds = Arrays.asList("some correlationId", "some other correlation id");
+        auditResultFetcher.getAuditResults(someCorrelationIds);
+
+        then(mockAuditClient).should(atLeastOnce())
+                             .getHistoryByCorrelationId(correlationIdCaptor.capture(), eq(expectedEventTypes));
+        assertThat(correlationIdCaptor.getAllValues()).containsOnlyElementsOf(someCorrelationIds);
+    }
+
+    @Test
+    public void getAuditResults_givenResultsFromAuditService_passedToConsolidator() {
+        stubConsolidator();
+
+        List<AuditRecord> someAuditRecords = asList(
+            new AuditRecord("some id", ANY_DATE_TIME, "some email", ANY_AUDIT_EVENT_TYPE, ANY_JSON, "some nino"),
+            new AuditRecord("some other id", ANY_DATE_TIME, "some email", ANY_AUDIT_EVENT_TYPE, ANY_JSON, "some nino"));
+        List<AuditRecord> someOtherAuditRecords = singletonList(
+            new AuditRecord("yet some other id", ANY_DATE_TIME, "some other email", ANY_AUDIT_EVENT_TYPE, ANY_JSON, "some other nino"));
+
+        given(mockAuditClient.getHistoryByCorrelationId(eq("some correlationId"), anyList()))
+            .willReturn(someAuditRecords);
+        given(mockAuditClient.getHistoryByCorrelationId(eq("some other correlation id"), anyList()))
+            .willReturn(someOtherAuditRecords);
+
+        List<String> someCorrelationIds = Arrays.asList("some correlationId", "some other correlation id");
+        auditResultFetcher.getAuditResults(someCorrelationIds);
+
+        then(mockConsolidator).should().getAuditResult(someAuditRecords);
+        then(mockConsolidator).should().getAuditResult(someOtherAuditRecords);
+    }
+
+    @Test
+    public void getAuditResults_multipleResultsPerNino_usesComparator() {
+        List<String> someCorrelationIds = Arrays.asList("some correlation id", "some other correlation id");
+
+        AuditResult passResult = new AuditResult("some correlation id", ANY_DATE, "some nino", AuditResultType.PASS);
+        AuditResult failResult = new AuditResult("some other correlation id", ANY_DATE, "some nino", AuditResultType.FAIL);
+        stubConsolidator(passResult, failResult);
+
+        auditResultFetcher.getAuditResults(someCorrelationIds);
+
+        then(mockComparator)
+            .should()
+            .compare(passResult, failResult);
+    }
+
+    private void stubConsolidator() {
+        when(mockConsolidator.getAuditResult(any()))
+            .thenReturn(ANY_AUDIT_RECORD);
+    }
+
+    private void stubConsolidator(AuditResult... results) {
+        AuditResult[] allResultsExceptFirst = ArrayUtils.subarray(results, 1, results.length);
+        when(mockConsolidator.getAuditResult(any()))
+            .thenReturn(results[0], allResultsExceptFirst);
+    }
+}

--- a/src/test/java/uk/gov/digital/ho/proving/income/audit/statistics/PassRateStatisticsServiceTest.java
+++ b/src/test/java/uk/gov/digital/ho/proving/income/audit/statistics/PassRateStatisticsServiceTest.java
@@ -85,6 +85,7 @@ public class PassRateStatisticsServiceTest {
 
     @Test
     public void generatePassStatistics_correlationIdsFromAuditService_callGetByCorrelationIdWithEachInTurn() {
+        // TODO EE-21001 Migrating to AuditResultFetcherTest.getAuditResults_someCorrelationIds_callGetByCorrelationIdWithEachInTurn
         List<String> expectedCorrelationIds = stubGetAllCorrelationIds("some correlationId", "some other correlation id");
 
         List<AuditRecord> anyAuditRecords = singletonList(new AuditRecord("any id", SOME_DATE_TIME, "any email", SOME_AUDIT_EVENT_TYPE, SOME_JSON, "any nino"));
@@ -129,7 +130,7 @@ public class PassRateStatisticsServiceTest {
 
     @Test
     public void generatePassStatistics_givenResultsFromAuditService_passedToConsolidator() {
-
+        // TODO EE-21001 Migrating to AuditResultFetcherTest.getAuditResults_givenResultsFromAuditService_passedToConsolidator
         stubGetAllCorrelationIds("some correlationId", "some other correlation id");
 
         List<AuditRecord> someAuditRecords = asList(
@@ -258,6 +259,7 @@ public class PassRateStatisticsServiceTest {
 
     @Test
     public void generatePassStatistics_multipleResultsPerNino_usesComparator() {
+        // TODO EE-21001 - Migrating to AuditResultFetcherTest.getAuditResults_multipleResultsPerNino_usesComparator
         stubGetAllCorrelationIds("some correlation id", "some other correlation id");
 
         AuditResult passResult = new AuditResult("some correlation id", SOME_DATE, "some nino", AuditResultType.PASS);

--- a/src/test/java/uk/gov/digital/ho/proving/income/audit/statistics/PassRateStatisticsServiceTest.java
+++ b/src/test/java/uk/gov/digital/ho/proving/income/audit/statistics/PassRateStatisticsServiceTest.java
@@ -173,6 +173,7 @@ public class PassRateStatisticsServiceTest {
 
     @Test
     public void generatePassStatistics_givenAuditResultsFromConsolidator_expectedListPassedToCalculator() {
+        // TODO EE-21001 Migrating to AuditResultFetcherTest.getAuditResults_givenResultsFromConsolidator_returned
         stubGetAllCorrelationIds("some correlation id", "some other correlation id");
 
         List<AuditResult> expectedResults = asList(
@@ -193,6 +194,7 @@ public class PassRateStatisticsServiceTest {
 
     @Test
     public void generatePassStatistics_multipleResultsPerNino_passOnlyBestToCalculator() {
+        // TODO EE-21001 Migrating to AuditResultFetcherTest.getAuditResults_multipleResultsPerNino_returnOnlyBest
         stubGetAllCorrelationIds("some correlation id", "some other correlation id");
 
         AuditResult passResult = new AuditResult("some correlation id", SOME_DATE, "some nino", AuditResultType.PASS);
@@ -213,6 +215,7 @@ public class PassRateStatisticsServiceTest {
 
     @Test
     public void generatePassStatistics_multipleResultsPerNino_passOldestBestResultToCalculator() {
+        // TODO EE-21001 Migrating to AuditResultFetcherTest.getAuditResults_multipleResultsPerNino_returnOldestBest
         stubGetAllCorrelationIds("some correlation id", "some other correlation id", "yet some other correlation id");
 
         AuditResult firstNotFound = new AuditResult("some correlation id", SOME_DATE, "some nino", AuditResultType.NOTFOUND);


### PR DESCRIPTION
Starting to split up the PassRateStatisticsService as it's unwieldy.  I have created a new AuditResultFetcher which will take all the getAuditResults(List<String> allCorrelationIds) logic out of the PassRateStatisticsService. In order to keep the transition digestible I have started by duplicating the logic in the new class, duplicating the tests etc. I will then consolidate in a PR to follow.

As the code is duplicated, Checkstyle has complained. I have temporarily added the ability to suppress Checkstyle and have suppressed the duplication warning.

As no observable behaviour should have changed, I intend to merge straight to master once approved.