### PR TITLE
EE-21001 Part two ofthe splitting of the PassRateStatisticsService

### DIFF
--- a/config/checkstyle/checkstyle.xml
+++ b/config/checkstyle/checkstyle.xml
@@ -115,5 +115,4 @@
         <property name="max" value="1000"/>
     </module>
     <module name="StrictDuplicateCode"/>
-    <module name="SuppressionCommentFilter"/><!--TODO EE-21001 Temporarily duplicating code which requires the supression, remove when refactoring complete -->
 </module>

--- a/src/test/java/uk/gov/digital/ho/proving/income/audit/statistics/PassRateStatisticsServiceCalendarMonthTest.java
+++ b/src/test/java/uk/gov/digital/ho/proving/income/audit/statistics/PassRateStatisticsServiceCalendarMonthTest.java
@@ -23,18 +23,16 @@ public class PassRateStatisticsServiceCalendarMonthTest {
     @Mock
     private AuditClient mockAuditClient;
     @Mock
-    private AuditResultConsolidator mockConsolidator;
-    @Mock
     private PassStatisticsCalculator mockPassStatisticsCalculator;
     @Mock
-    private AuditResultComparator mockResultComparator;
+    private AuditResultFetcher mockAuditResultFetcher;
 
     private PassRateStatisticsService service;
 
     @Before
     public void setUp() {
         int anyInt = 5;
-        service = new PassRateStatisticsService(mockAuditClient, mockPassStatisticsCalculator, mockConsolidator, mockResultComparator, anyInt);
+        service = new PassRateStatisticsService(mockAuditClient, mockPassStatisticsCalculator, mockAuditResultFetcher, anyInt);
     }
 
     @Test


### PR DESCRIPTION
Completed the split of PassRateStatisticsService by moving some of its logic into AuditResultFetcher. I have tidied up any TODOs and removed the old versions of the migrated tests. I have have added new tests to ensure that PassRateStatisticsService is using its new AuditResultFetcher collaborator correctly.

As no observable function has changed I will merge to master once approved.