### PR TITLE
EE-21001 Changed the ArchiveAuditRequest and AuditResultByNino to use a Set for correlationIds

### DIFF
--- a/src/main/java/uk/gov/digital/ho/proving/income/audit/ArchiveAuditRequest.java
+++ b/src/main/java/uk/gov/digital/ho/proving/income/audit/ArchiveAuditRequest.java
@@ -5,7 +5,7 @@ import lombok.*;
 import lombok.experimental.Accessors;
 
 import java.time.LocalDate;
-import java.util.List;
+import java.util.Set;
 
 @Builder
 @Getter
@@ -18,7 +18,7 @@ class ArchiveAuditRequest {
     @JsonProperty
     private LocalDate lastArchiveDate;
     @JsonProperty
-    private List<String> correlationIds;
+    private Set<String> correlationIds;
     @JsonProperty
     private String nino;
 }

--- a/src/main/java/uk/gov/digital/ho/proving/income/audit/AuditResultByNino.java
+++ b/src/main/java/uk/gov/digital/ho/proving/income/audit/AuditResultByNino.java
@@ -7,7 +7,7 @@ import lombok.ToString;
 import lombok.experimental.Accessors;
 
 import java.time.LocalDate;
-import java.util.List;
+import java.util.Set;
 
 @AllArgsConstructor
 @Getter
@@ -16,7 +16,7 @@ import java.util.List;
 @ToString
 public class AuditResultByNino {
     private String nino;
-    private List<String> correlationIds;
+    private Set<String> correlationIds;
     private LocalDate date;
     private AuditResultType resultType;
 }

--- a/src/main/java/uk/gov/digital/ho/proving/income/audit/AuditResultConsolidator.java
+++ b/src/main/java/uk/gov/digital/ho/proving/income/audit/AuditResultConsolidator.java
@@ -6,6 +6,7 @@ import java.time.LocalDate;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
+import java.util.Set;
 import java.util.stream.Collectors;
 
 import static uk.gov.digital.ho.proving.income.audit.AuditEventType.INCOME_PROVING_FINANCIAL_STATUS_REQUEST;
@@ -55,9 +56,9 @@ public class AuditResultConsolidator {
         if (consolidatedResult == null) {
             return null;
         }
-        List<String> allCorrelationIds = results.stream()
-            .map(AuditResult::correlationId)
-            .collect(Collectors.toList());
+        Set<String> allCorrelationIds = results.stream()
+                                               .map(AuditResult::correlationId)
+                                               .collect(Collectors.toSet());
         return new AuditResultByNino(consolidatedResult.nino(), allCorrelationIds, consolidatedResult.date(), consolidatedResult.resultType());
     }
 

--- a/src/test/java/uk/gov/digital/ho/proving/income/audit/AuditArchiveServiceTest.java
+++ b/src/test/java/uk/gov/digital/ho/proving/income/audit/AuditArchiveServiceTest.java
@@ -1,5 +1,6 @@
 package uk.gov.digital.ho.proving.income.audit;
 
+import com.google.common.collect.ImmutableSet;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -57,7 +58,7 @@ public class AuditArchiveServiceTest {
     }
 
     private List<AuditResultByNino> getAuditResultsByNino() {
-        AuditResultByNino auditResult = new AuditResultByNino("any_nino", Arrays.asList("any_corr_id"), LocalDate.now().minusMonths(7), PASS);
+        AuditResultByNino auditResult = new AuditResultByNino("any_nino", ImmutableSet.of("any_corr_id"), LocalDate.now().minusMonths(7), PASS);
         return Arrays.asList(auditResult);
     }
 

--- a/src/test/java/uk/gov/digital/ho/proving/income/audit/AuditClientTest.java
+++ b/src/test/java/uk/gov/digital/ho/proving/income/audit/AuditClientTest.java
@@ -8,6 +8,7 @@ import ch.qos.logback.core.Appender;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.common.collect.ImmutableSet;
 import net.logstash.logback.marker.ObjectAppendingMarker;
 import org.junit.AfterClass;
 import org.junit.Before;
@@ -303,7 +304,7 @@ public class AuditClientTest {
 
     @Test
     public void archiveAudit_shouldRequestAuditArchive() {
-        ArchiveAuditRequest request = new ArchiveAuditRequest("any_nino", LocalDate.now().minusMonths(6), asList("corr1", "corr2"), "PASS");
+        ArchiveAuditRequest request = new ArchiveAuditRequest("any_nino", LocalDate.now().minusMonths(6), ImmutableSet.of("corr1", "corr2"), "PASS");
         when(mockRestTemplate.exchange(eq(SOME_ARCHIVE_ENDPOINT + "/2019-06-30"), eq(POST), captorHttpEntity.capture(), eq(Void.class))).thenReturn(ResponseEntity.ok(null));
 
         auditClient.archiveAudit(request, LocalDate.of(2019, 6, 30));
@@ -315,7 +316,7 @@ public class AuditClientTest {
 
     @Test
     public void archiveAudit_shouldFormatResultDateOnUrl() {
-        ArchiveAuditRequest request = new ArchiveAuditRequest("any_nino", LocalDate.now().minusMonths(6), asList("corr1", "corr2"), "PASS");
+        ArchiveAuditRequest request = new ArchiveAuditRequest("any_nino", LocalDate.now().minusMonths(6), ImmutableSet.of("corr1", "corr2"), "PASS");
         when(mockRestTemplate.exchange(captorUrl.capture(), eq(POST), captorHttpEntity.capture(), eq(Void.class))).thenReturn(ResponseEntity.ok(null));
 
         auditClient.archiveAudit(request, LocalDate.of(2019, 6, 30));
@@ -326,7 +327,7 @@ public class AuditClientTest {
 
     @Test
     public void archiveAudit_shouldLogAuditArchiveErrors() {
-        ArchiveAuditRequest request = new ArchiveAuditRequest("any_nino", LocalDate.now().minusMonths(6), asList("corr1", "corr2"), "PASS");
+        ArchiveAuditRequest request = new ArchiveAuditRequest("any_nino", LocalDate.now().minusMonths(6), ImmutableSet.of("corr1", "corr2"), "PASS");
         when(mockRestTemplate.exchange(eq(SOME_ARCHIVE_ENDPOINT + "/2019-06-30"), eq(POST), captorHttpEntity.capture(), eq(Void.class)))
             .thenThrow(new RestClientException("exception text"));
         LogCapturer<AuditClient> logCapturer = LogCapturer.forClass(AuditClient.class);

--- a/src/test/java/uk/gov/digital/ho/proving/income/audit/AuditResultConsolidatorIT.java
+++ b/src/test/java/uk/gov/digital/ho/proving/income/audit/AuditResultConsolidatorIT.java
@@ -1,6 +1,7 @@
 package uk.gov.digital.ho.proving.income.audit;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.common.collect.ImmutableSet;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -9,10 +10,7 @@ import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.junit4.SpringRunner;
 
 import java.time.LocalDate;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Collections;
-import java.util.List;
+import java.util.*;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static uk.gov.digital.ho.proving.income.audit.AuditResultType.*;
@@ -188,7 +186,7 @@ public class AuditResultConsolidatorIT {
     @Test
     public void byNino_singleResult_resultUsed() {
         List<AuditResult> results = Arrays.asList(new AuditResult("any_correlation_id", LocalDate.now(), "any_nino", PASS));
-        AuditResultByNino expected = new AuditResultByNino("any_nino", Arrays.asList("any_correlation_id"), LocalDate.now(), PASS);
+        AuditResultByNino expected = new AuditResultByNino("any_nino", ImmutableSet.of("any_correlation_id"), LocalDate.now(), PASS);
 
         List<AuditResultByNino> resultsByNino = auditResultConsolidator.consolidatedAuditResultsByNino(results);
 
@@ -205,7 +203,7 @@ public class AuditResultConsolidatorIT {
                 new AuditResult("any_correlation_id_3", LocalDate.now(), "any_nino", NOTFOUND),
                 new AuditResult("any_correlation_id_4", LocalDate.now(), "any_nino", ERROR)
             );
-        List<String> expectedCorrelationIds = Arrays.asList(
+        Set<String> expectedCorrelationIds = ImmutableSet.of(
             "any_correlation_id",
             "any_correlation_id_2",
             "any_correlation_id_3",
@@ -228,7 +226,7 @@ public class AuditResultConsolidatorIT {
                 new AuditResult("any_correlation_id_3", LocalDate.now().plusDays(2), "any_nino", PASS),
                 new AuditResult("any_correlation_id_4", LocalDate.now().plusDays(1), "any_nino", PASS)
             );
-        List<String> expectedCorrelationIds = Arrays.asList(
+        Set<String> expectedCorrelationIds = ImmutableSet.of(
             "any_correlation_id",
             "any_correlation_id_2",
             "any_correlation_id_3",
@@ -250,8 +248,8 @@ public class AuditResultConsolidatorIT {
                 new AuditResult("any_correlation_id_2", LocalDate.now().plusDays(1), "any_nino_2", PASS)
             );
         List<AuditResultByNino> expected = Arrays.asList(
-                new AuditResultByNino("any_nino", Arrays.asList("any_correlation_id"), LocalDate.now(), PASS),
-                new AuditResultByNino("any_nino_2", Arrays.asList("any_correlation_id_2"), LocalDate.now().plusDays(1), PASS)
+                new AuditResultByNino("any_nino", ImmutableSet.of("any_correlation_id"), LocalDate.now(), PASS),
+                new AuditResultByNino("any_nino_2", ImmutableSet.of("any_correlation_id_2"), LocalDate.now().plusDays(1), PASS)
             );
 
         List<AuditResultByNino> resultsByNino = auditResultConsolidator.consolidatedAuditResultsByNino(results);
@@ -270,8 +268,8 @@ public class AuditResultConsolidatorIT {
                 new AuditResult("any_correlation_id_4", LocalDate.now().plusDays(1), "any_nino_2", PASS)
             );
         List<AuditResultByNino> expected = Arrays.asList(
-                new AuditResultByNino("any_nino", Arrays.asList("any_correlation_id_2", "any_correlation_id"), LocalDate.now(), PASS),
-                new AuditResultByNino("any_nino_2", Arrays.asList("any_correlation_id_3", "any_correlation_id_4"), LocalDate.now(), PASS)
+                new AuditResultByNino("any_nino", ImmutableSet.of("any_correlation_id_2", "any_correlation_id"), LocalDate.now(), PASS),
+                new AuditResultByNino("any_nino_2", ImmutableSet.of("any_correlation_id_3", "any_correlation_id_4"), LocalDate.now(), PASS)
             );
 
         List<AuditResultByNino> resultsByNino = auditResultConsolidator.consolidatedAuditResultsByNino(results);


### PR DESCRIPTION
The order is not important for the correlation IDs but they should not be duplicated so a Set is more appropriate than a List.

The integration tests for this service give some confidence that I haven't changed the Archiving Request that this service sends to audit-service. I have also managed to convince myself that when Spring converts a Set into an HTTP request body, it uses the same form as a List, meaning that audit-service does not need to be changed.

For the above reasons I intend to merge this to master. In the highly unlikely event that this change has broken something it will be picked up when EE-21001 is tested. Also archving is resilient enough that it would not be impacted if it was broken for a day or two - it would catch up when fixed.