### PR TITLE
Ee 21001 Rename AuditResultByNino to ConsolidatedAuditResult

### DIFF
--- a/src/main/java/uk/gov/digital/ho/proving/income/audit/AuditArchiveService.java
+++ b/src/main/java/uk/gov/digital/ho/proving/income/audit/AuditArchiveService.java
@@ -34,9 +34,9 @@ class AuditArchiveService {
 
         List<AuditRecord> auditHistory = auditClient.getAuditHistory(getLastDayToBeArchived(), AUDIT_EVENTS_TO_ARCHIVE);
         List<AuditResult> byCorrelationId = auditResultConsolidator.auditResultsByCorrelationId(auditHistory);
-        List<AuditResultByNino> consolidatedByNino = auditResultConsolidator.consolidatedAuditResultsByNino(byCorrelationId);
+        List<ConsolidatedAuditResult> consolidatedByNino = auditResultConsolidator.consolidatedAuditResultsByNino(byCorrelationId);
 
-        for (AuditResultByNino auditResult : consolidatedByNino) {
+        for (ConsolidatedAuditResult auditResult : consolidatedByNino) {
             auditClient.archiveAudit(generateAuditHistoryRequest(auditResult, config), auditResult.date());
         }
     }
@@ -45,7 +45,7 @@ class AuditArchiveService {
         return LocalDate.now().minusMonths(retainAuditHistoryMonths).minusDays(1);
     }
 
-    private ArchiveAuditRequest generateAuditHistoryRequest(AuditResultByNino auditResult, AuditArchiveConfig config) {
+    private ArchiveAuditRequest generateAuditHistoryRequest(ConsolidatedAuditResult auditResult, AuditArchiveConfig config) {
         return ArchiveAuditRequest.builder()
             .nino(auditResult.nino())
             .correlationIds(auditResult.correlationIds())

--- a/src/main/java/uk/gov/digital/ho/proving/income/audit/AuditResultConsolidator.java
+++ b/src/main/java/uk/gov/digital/ho/proving/income/audit/AuditResultConsolidator.java
@@ -38,7 +38,7 @@ public class AuditResultConsolidator {
             .collect(Collectors.toList());
     }
 
-    public List<AuditResultByNino> consolidatedAuditResultsByNino(List<AuditResult> results) {
+    public List<ConsolidatedAuditResult> consolidatedAuditResultsByNino(List<AuditResult> results) {
         Map<String, List<AuditResult>> resultsByNino =
             results.stream().collect(Collectors.groupingBy(AuditResult::nino));
 
@@ -48,7 +48,7 @@ public class AuditResultConsolidator {
             .collect(Collectors.toList());
     }
 
-    private AuditResultByNino consolidateFirstBestResult(List<AuditResult> results) {
+    private ConsolidatedAuditResult consolidateFirstBestResult(List<AuditResult> results) {
         AuditResult consolidatedResult = results.stream()
             .max(auditResultComparator)
             .orElse(null);
@@ -58,7 +58,7 @@ public class AuditResultConsolidator {
         List<String> allCorrelationIds = results.stream()
             .map(AuditResult::correlationId)
             .collect(Collectors.toList());
-        return new AuditResultByNino(consolidatedResult.nino(), allCorrelationIds, consolidatedResult.date(), consolidatedResult.resultType());
+        return new ConsolidatedAuditResult(consolidatedResult.nino(), allCorrelationIds, consolidatedResult.date(), consolidatedResult.resultType());
     }
 
     public AuditResult getAuditResult(List<AuditRecord> auditRecords) {

--- a/src/main/java/uk/gov/digital/ho/proving/income/audit/ConsolidatedAuditResult.java
+++ b/src/main/java/uk/gov/digital/ho/proving/income/audit/ConsolidatedAuditResult.java
@@ -14,7 +14,7 @@ import java.util.List;
 @Accessors(fluent = true)
 @EqualsAndHashCode
 @ToString
-public class AuditResultByNino {
+public class ConsolidatedAuditResult {
     private String nino;
     private List<String> correlationIds;
     private LocalDate date;

--- a/src/test/java/uk/gov/digital/ho/proving/income/audit/AuditArchiveServiceTest.java
+++ b/src/test/java/uk/gov/digital/ho/proving/income/audit/AuditArchiveServiceTest.java
@@ -40,7 +40,7 @@ public class AuditArchiveServiceTest {
         when(mockAuditClient.getAuditHistory(auditEndDate, AUDIT_EVENTS_TO_ARCHIVE)).thenReturn(history);
         List<AuditResult> resultsByCorrelationId = getAuditResultsByCorrelationId();
         when(mockAuditResultConsolidator.auditResultsByCorrelationId(anyList())).thenReturn(resultsByCorrelationId);
-        List<AuditResultByNino> resultsByNino = getAuditResultsByNino();
+        List<ConsolidatedAuditResult> resultsByNino = getAuditResultsByNino();
         when(mockAuditResultConsolidator.consolidatedAuditResultsByNino(anyList())).thenReturn(resultsByNino);
 
         auditArchiveService.archiveAudit();
@@ -56,8 +56,8 @@ public class AuditArchiveServiceTest {
         return Arrays.asList(auditResult);
     }
 
-    private List<AuditResultByNino> getAuditResultsByNino() {
-        AuditResultByNino auditResult = new AuditResultByNino("any_nino", Arrays.asList("any_corr_id"), LocalDate.now().minusMonths(7), PASS);
+    private List<ConsolidatedAuditResult> getAuditResultsByNino() {
+        ConsolidatedAuditResult auditResult = new ConsolidatedAuditResult("any_nino", Arrays.asList("any_corr_id"), LocalDate.now().minusMonths(7), PASS);
         return Arrays.asList(auditResult);
     }
 

--- a/src/test/java/uk/gov/digital/ho/proving/income/audit/AuditResultConsolidatorIT.java
+++ b/src/test/java/uk/gov/digital/ho/proving/income/audit/AuditResultConsolidatorIT.java
@@ -252,7 +252,7 @@ public class AuditResultConsolidatorIT {
         List<ConsolidatedAuditResult> expected = Arrays.asList(
                 new ConsolidatedAuditResult("any_nino", Arrays.asList("any_correlation_id"), LocalDate.now(), PASS),
                 new ConsolidatedAuditResult("any_nino_2", Arrays.asList("any_correlation_id_2"), LocalDate.now().plusDays(1), PASS)
-                                                              );
+            );
 
         List<ConsolidatedAuditResult> resultsByNino = auditResultConsolidator.consolidatedAuditResultsByNino(results);
 
@@ -272,7 +272,7 @@ public class AuditResultConsolidatorIT {
         List<ConsolidatedAuditResult> expected = Arrays.asList(
                 new ConsolidatedAuditResult("any_nino", Arrays.asList("any_correlation_id_2", "any_correlation_id"), LocalDate.now(), PASS),
                 new ConsolidatedAuditResult("any_nino_2", Arrays.asList("any_correlation_id_3", "any_correlation_id_4"), LocalDate.now(), PASS)
-                                                              );
+            );
 
         List<ConsolidatedAuditResult> resultsByNino = auditResultConsolidator.consolidatedAuditResultsByNino(results);
 

--- a/src/test/java/uk/gov/digital/ho/proving/income/audit/AuditResultConsolidatorIT.java
+++ b/src/test/java/uk/gov/digital/ho/proving/income/audit/AuditResultConsolidatorIT.java
@@ -180,7 +180,7 @@ public class AuditResultConsolidatorIT {
     public void byNino_noResults_empty() {
         List<AuditResult> results = new ArrayList<>();
 
-        List<AuditResultByNino> resultsByNino = auditResultConsolidator.consolidatedAuditResultsByNino(results);
+        List<ConsolidatedAuditResult> resultsByNino = auditResultConsolidator.consolidatedAuditResultsByNino(results);
 
         assertThat(resultsByNino.size()).isEqualTo(0);
     }
@@ -188,9 +188,9 @@ public class AuditResultConsolidatorIT {
     @Test
     public void byNino_singleResult_resultUsed() {
         List<AuditResult> results = Arrays.asList(new AuditResult("any_correlation_id", LocalDate.now(), "any_nino", PASS));
-        AuditResultByNino expected = new AuditResultByNino("any_nino", Arrays.asList("any_correlation_id"), LocalDate.now(), PASS);
+        ConsolidatedAuditResult expected = new ConsolidatedAuditResult("any_nino", Arrays.asList("any_correlation_id"), LocalDate.now(), PASS);
 
-        List<AuditResultByNino> resultsByNino = auditResultConsolidator.consolidatedAuditResultsByNino(results);
+        List<ConsolidatedAuditResult> resultsByNino = auditResultConsolidator.consolidatedAuditResultsByNino(results);
 
         assertThat(resultsByNino.size()).isEqualTo(1);
         assertThat(resultsByNino.get(0)).isEqualTo(expected);
@@ -211,9 +211,9 @@ public class AuditResultConsolidatorIT {
             "any_correlation_id_3",
             "any_correlation_id_4"
         );
-        AuditResultByNino expected = new AuditResultByNino("any_nino", expectedCorrelationIds, LocalDate.now(), PASS);
+        ConsolidatedAuditResult expected = new ConsolidatedAuditResult("any_nino", expectedCorrelationIds, LocalDate.now(), PASS);
 
-        List<AuditResultByNino> resultsByNino = auditResultConsolidator.consolidatedAuditResultsByNino(results);
+        List<ConsolidatedAuditResult> resultsByNino = auditResultConsolidator.consolidatedAuditResultsByNino(results);
 
         assertThat(resultsByNino.size()).isEqualTo(1);
         assertThat(resultsByNino.get(0)).isEqualTo(expected);
@@ -234,9 +234,9 @@ public class AuditResultConsolidatorIT {
             "any_correlation_id_3",
             "any_correlation_id_4"
         );
-        AuditResultByNino expected = new AuditResultByNino("any_nino", expectedCorrelationIds, LocalDate.now(), PASS);
+        ConsolidatedAuditResult expected = new ConsolidatedAuditResult("any_nino", expectedCorrelationIds, LocalDate.now(), PASS);
 
-        List<AuditResultByNino> resultsByNino = auditResultConsolidator.consolidatedAuditResultsByNino(results);
+        List<ConsolidatedAuditResult> resultsByNino = auditResultConsolidator.consolidatedAuditResultsByNino(results);
 
         assertThat(resultsByNino.size()).isEqualTo(1);
         assertThat(resultsByNino.get(0)).isEqualTo(expected);
@@ -249,12 +249,12 @@ public class AuditResultConsolidatorIT {
                 new AuditResult("any_correlation_id", LocalDate.now(), "any_nino", PASS),
                 new AuditResult("any_correlation_id_2", LocalDate.now().plusDays(1), "any_nino_2", PASS)
             );
-        List<AuditResultByNino> expected = Arrays.asList(
-                new AuditResultByNino("any_nino", Arrays.asList("any_correlation_id"), LocalDate.now(), PASS),
-                new AuditResultByNino("any_nino_2", Arrays.asList("any_correlation_id_2"), LocalDate.now().plusDays(1), PASS)
-            );
+        List<ConsolidatedAuditResult> expected = Arrays.asList(
+                new ConsolidatedAuditResult("any_nino", Arrays.asList("any_correlation_id"), LocalDate.now(), PASS),
+                new ConsolidatedAuditResult("any_nino_2", Arrays.asList("any_correlation_id_2"), LocalDate.now().plusDays(1), PASS)
+                                                              );
 
-        List<AuditResultByNino> resultsByNino = auditResultConsolidator.consolidatedAuditResultsByNino(results);
+        List<ConsolidatedAuditResult> resultsByNino = auditResultConsolidator.consolidatedAuditResultsByNino(results);
 
         assertThat(resultsByNino.size()).isEqualTo(2);
         assertThat(resultsByNino).contains(expected.get(0), expected.get(1));
@@ -269,12 +269,12 @@ public class AuditResultConsolidatorIT {
                 new AuditResult("any_correlation_id_3", LocalDate.now(), "any_nino_2", PASS),
                 new AuditResult("any_correlation_id_4", LocalDate.now().plusDays(1), "any_nino_2", PASS)
             );
-        List<AuditResultByNino> expected = Arrays.asList(
-                new AuditResultByNino("any_nino", Arrays.asList("any_correlation_id_2", "any_correlation_id"), LocalDate.now(), PASS),
-                new AuditResultByNino("any_nino_2", Arrays.asList("any_correlation_id_3", "any_correlation_id_4"), LocalDate.now(), PASS)
-            );
+        List<ConsolidatedAuditResult> expected = Arrays.asList(
+                new ConsolidatedAuditResult("any_nino", Arrays.asList("any_correlation_id_2", "any_correlation_id"), LocalDate.now(), PASS),
+                new ConsolidatedAuditResult("any_nino_2", Arrays.asList("any_correlation_id_3", "any_correlation_id_4"), LocalDate.now(), PASS)
+                                                              );
 
-        List<AuditResultByNino> resultsByNino = auditResultConsolidator.consolidatedAuditResultsByNino(results);
+        List<ConsolidatedAuditResult> resultsByNino = auditResultConsolidator.consolidatedAuditResultsByNino(results);
 
         assertThat(resultsByNino.size()).isEqualTo(2);
         assertThat(resultsByNino).contains(expected.get(0), expected.get(1));


### PR DESCRIPTION
When the cutoff logic is applied there won't necessarily be a one-to-one mapping between Ninos and ArchiveRequests. The AuditResultByNino name would be misleading so I am changing it.

I intend to merge once approved.