### PR TITLE
Ee 21001 Rename consolidatedAuditResultsByNino to consolidatedAuditResults

### DIFF
--- a/src/main/java/uk/gov/digital/ho/proving/income/audit/AuditArchiveService.java
+++ b/src/main/java/uk/gov/digital/ho/proving/income/audit/AuditArchiveService.java
@@ -34,7 +34,7 @@ class AuditArchiveService {
 
         List<AuditRecord> auditHistory = auditClient.getAuditHistory(getLastDayToBeArchived(), AUDIT_EVENTS_TO_ARCHIVE);
         List<AuditResult> byCorrelationId = auditResultConsolidator.auditResultsByCorrelationId(auditHistory);
-        List<ConsolidatedAuditResult> consolidatedByNino = auditResultConsolidator.consolidatedAuditResultsByNino(byCorrelationId);
+        List<ConsolidatedAuditResult> consolidatedByNino = auditResultConsolidator.consolidatedAuditResults(byCorrelationId);
 
         for (ConsolidatedAuditResult auditResult : consolidatedByNino) {
             auditClient.archiveAudit(generateAuditHistoryRequest(auditResult, config), auditResult.date());

--- a/src/main/java/uk/gov/digital/ho/proving/income/audit/AuditResultConsolidator.java
+++ b/src/main/java/uk/gov/digital/ho/proving/income/audit/AuditResultConsolidator.java
@@ -38,7 +38,7 @@ public class AuditResultConsolidator {
             .collect(Collectors.toList());
     }
 
-    public List<ConsolidatedAuditResult> consolidatedAuditResultsByNino(List<AuditResult> results) {
+    public List<ConsolidatedAuditResult> consolidatedAuditResults(List<AuditResult> results) {
         Map<String, List<AuditResult>> resultsByNino =
             results.stream().collect(Collectors.groupingBy(AuditResult::nino));
 

--- a/src/test/java/uk/gov/digital/ho/proving/income/audit/AuditArchiveServiceTest.java
+++ b/src/test/java/uk/gov/digital/ho/proving/income/audit/AuditArchiveServiceTest.java
@@ -41,13 +41,13 @@ public class AuditArchiveServiceTest {
         List<AuditResult> resultsByCorrelationId = getAuditResultsByCorrelationId();
         when(mockAuditResultConsolidator.auditResultsByCorrelationId(anyList())).thenReturn(resultsByCorrelationId);
         List<ConsolidatedAuditResult> resultsByNino = getAuditResultsByNino();
-        when(mockAuditResultConsolidator.consolidatedAuditResultsByNino(anyList())).thenReturn(resultsByNino);
+        when(mockAuditResultConsolidator.consolidatedAuditResults(anyList())).thenReturn(resultsByNino);
 
         auditArchiveService.archiveAudit();
 
         verify(mockAuditClient).getAuditHistory(auditEndDate, AUDIT_EVENTS_TO_ARCHIVE);
         verify(mockAuditResultConsolidator).auditResultsByCorrelationId(history);
-        verify(mockAuditResultConsolidator).consolidatedAuditResultsByNino(resultsByCorrelationId);
+        verify(mockAuditResultConsolidator).consolidatedAuditResults(resultsByCorrelationId);
         verify(mockAuditClient).archiveAudit(any(ArchiveAuditRequest.class), any(LocalDate.class));
     }
 

--- a/src/test/java/uk/gov/digital/ho/proving/income/audit/AuditResultConsolidatorIT.java
+++ b/src/test/java/uk/gov/digital/ho/proving/income/audit/AuditResultConsolidatorIT.java
@@ -174,30 +174,30 @@ public class AuditResultConsolidatorIT {
     }
 
     /*
-     * auditResultsByNino
+     * consolidatedAuditResults
      */
     @Test
-    public void byNino_noResults_empty() {
+    public void consolidate_noResults_empty() {
         List<AuditResult> results = new ArrayList<>();
 
-        List<ConsolidatedAuditResult> resultsByNino = auditResultConsolidator.consolidatedAuditResultsByNino(results);
+        List<ConsolidatedAuditResult> resultsByNino = auditResultConsolidator.consolidatedAuditResults(results);
 
         assertThat(resultsByNino.size()).isEqualTo(0);
     }
 
     @Test
-    public void byNino_singleResult_resultUsed() {
+    public void consolidate_singleResult_resultUsed() {
         List<AuditResult> results = Arrays.asList(new AuditResult("any_correlation_id", LocalDate.now(), "any_nino", PASS));
         ConsolidatedAuditResult expected = new ConsolidatedAuditResult("any_nino", Arrays.asList("any_correlation_id"), LocalDate.now(), PASS);
 
-        List<ConsolidatedAuditResult> resultsByNino = auditResultConsolidator.consolidatedAuditResultsByNino(results);
+        List<ConsolidatedAuditResult> resultsByNino = auditResultConsolidator.consolidatedAuditResults(results);
 
         assertThat(resultsByNino.size()).isEqualTo(1);
         assertThat(resultsByNino.get(0)).isEqualTo(expected);
     }
 
     @Test
-    public void byNino_multipleResults_bestResultUsed() {
+    public void consolidate_multipleResults_bestResultUsed() {
         List<AuditResult> results =
             Arrays.asList(
                 new AuditResult("any_correlation_id", LocalDate.now(), "any_nino", PASS),
@@ -213,14 +213,14 @@ public class AuditResultConsolidatorIT {
         );
         ConsolidatedAuditResult expected = new ConsolidatedAuditResult("any_nino", expectedCorrelationIds, LocalDate.now(), PASS);
 
-        List<ConsolidatedAuditResult> resultsByNino = auditResultConsolidator.consolidatedAuditResultsByNino(results);
+        List<ConsolidatedAuditResult> resultsByNino = auditResultConsolidator.consolidatedAuditResults(results);
 
         assertThat(resultsByNino.size()).isEqualTo(1);
         assertThat(resultsByNino.get(0)).isEqualTo(expected);
     }
 
     @Test
-    public void byNino_multipleSameResults_oldestUsed() {
+    public void consolidate_multipleSameResults_oldestUsed() {
         List<AuditResult> results =
             Arrays.asList(
                 new AuditResult("any_correlation_id", LocalDate.now(), "any_nino", PASS),
@@ -236,14 +236,14 @@ public class AuditResultConsolidatorIT {
         );
         ConsolidatedAuditResult expected = new ConsolidatedAuditResult("any_nino", expectedCorrelationIds, LocalDate.now(), PASS);
 
-        List<ConsolidatedAuditResult> resultsByNino = auditResultConsolidator.consolidatedAuditResultsByNino(results);
+        List<ConsolidatedAuditResult> resultsByNino = auditResultConsolidator.consolidatedAuditResults(results);
 
         assertThat(resultsByNino.size()).isEqualTo(1);
         assertThat(resultsByNino.get(0)).isEqualTo(expected);
     }
 
     @Test
-    public void byNino_multipleNinos_allIncluded() {
+    public void consolidate_multipleNinos_allIncluded() {
         List<AuditResult> results =
             Arrays.asList(
                 new AuditResult("any_correlation_id", LocalDate.now(), "any_nino", PASS),
@@ -254,14 +254,14 @@ public class AuditResultConsolidatorIT {
                 new ConsolidatedAuditResult("any_nino_2", Arrays.asList("any_correlation_id_2"), LocalDate.now().plusDays(1), PASS)
             );
 
-        List<ConsolidatedAuditResult> resultsByNino = auditResultConsolidator.consolidatedAuditResultsByNino(results);
+        List<ConsolidatedAuditResult> resultsByNino = auditResultConsolidator.consolidatedAuditResults(results);
 
         assertThat(resultsByNino.size()).isEqualTo(2);
         assertThat(resultsByNino).contains(expected.get(0), expected.get(1));
     }
 
     @Test
-    public void byNino_multipleNinosAndResults_correctResultsIncluded() {
+    public void consolidate_multipleNinosAndResults_correctResultsIncluded() {
         List<AuditResult> results =
             Arrays.asList(
                 new AuditResult("any_correlation_id_2", LocalDate.now(), "any_nino", FAIL),
@@ -274,7 +274,7 @@ public class AuditResultConsolidatorIT {
                 new ConsolidatedAuditResult("any_nino_2", Arrays.asList("any_correlation_id_3", "any_correlation_id_4"), LocalDate.now(), PASS)
             );
 
-        List<ConsolidatedAuditResult> resultsByNino = auditResultConsolidator.consolidatedAuditResultsByNino(results);
+        List<ConsolidatedAuditResult> resultsByNino = auditResultConsolidator.consolidatedAuditResults(results);
 
         assertThat(resultsByNino.size()).isEqualTo(2);
         assertThat(resultsByNino).contains(expected.get(0), expected.get(1));


### PR DESCRIPTION
As this method will be separating results based on the cutoff date (change still to come), there won't necessarily be a one-to-one mapping from nino to consolidated result. Therefore the method name needs to be changed.

I intend to merge once approved.