### PR TITLE
Ee 21001 do archiving cutoff

### DIFF
--- a/src/main/java/uk/gov/digital/ho/proving/income/audit/AuditResultConsolidator.java
+++ b/src/main/java/uk/gov/digital/ho/proving/income/audit/AuditResultConsolidator.java
@@ -4,10 +4,7 @@ import org.springframework.stereotype.Component;
 import uk.gov.digital.ho.proving.income.audit.statistics.AuditResultsGroupedByNino;
 
 import java.time.LocalDate;
-import java.util.Collection;
-import java.util.List;
-import java.util.Map;
-import java.util.Objects;
+import java.util.*;
 import java.util.stream.Collectors;
 
 import static uk.gov.digital.ho.proving.income.audit.AuditEventType.INCOME_PROVING_FINANCIAL_STATUS_REQUEST;
@@ -56,11 +53,11 @@ public class AuditResultConsolidator {
 
     private List<AuditResultsGroupedByNino> groupByNino(Collection<List<AuditResult>> resultsByNino) {
         return resultsByNino.stream()
-                            .map(AuditResultsGroupedByNino::of)
+                            .map(AuditResultsGroupedByNino::new)
                             .collect(Collectors.toList());
     }
 
-    private List<List<AuditResult>> separateByCutoff(List<AuditResultsGroupedByNino> resultsByNino) {
+    private List<AuditResultsGroupedByNino> separateByCutoff(List<AuditResultsGroupedByNino> resultsByNino) {
         return resultsByNino.stream()
                             .map(resultCutoffSeparator::separateResultsByCutoff)
                             .flatMap(Collection::stream)

--- a/src/main/java/uk/gov/digital/ho/proving/income/audit/AuditResultConsolidator.java
+++ b/src/main/java/uk/gov/digital/ho/proving/income/audit/AuditResultConsolidator.java
@@ -1,8 +1,10 @@
 package uk.gov.digital.ho.proving.income.audit;
 
 import org.springframework.stereotype.Component;
+import uk.gov.digital.ho.proving.income.audit.statistics.AuditResultsGroupedByNino;
 
 import java.time.LocalDate;
+import java.util.Collection;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
@@ -18,15 +20,17 @@ public class AuditResultConsolidator {
     private AuditResultParser auditResultParser;
     private AuditResultTypeComparator auditResultTypeComparator;
     private AuditResultComparator auditResultComparator;
+    private ResultCutoffSeparator resultCutoffSeparator;
 
     public AuditResultConsolidator(
         AuditResultParser auditResultParser,
         AuditResultTypeComparator auditResultTypeComparator,
-        AuditResultComparator auditResultComparator
-    ) {
+        AuditResultComparator auditResultComparator,
+        ResultCutoffSeparator resultCutoffSeparator) {
         this.auditResultParser = auditResultParser;
         this.auditResultTypeComparator = auditResultTypeComparator;
         this.auditResultComparator = auditResultComparator;
+        this.resultCutoffSeparator = resultCutoffSeparator;
     }
 
     public List<AuditResult> auditResultsByCorrelationId(List<AuditRecord> auditRecords) {
@@ -43,12 +47,15 @@ public class AuditResultConsolidator {
             results.stream().collect(Collectors.groupingBy(AuditResult::nino));
 
         return resultsByNino.values().stream()
-            .map(this::consolidateFirstBestResult)
-            .filter(Objects::nonNull)
-            .collect(Collectors.toList());
+                            .map(AuditResultsGroupedByNino::of)
+                            .map(resultCutoffSeparator::separateResultsByCutoff)
+                            .flatMap(Collection::stream)
+                            .map(this::consolidateFirstBestResult)
+                            .filter(Objects::nonNull)
+                            .collect(Collectors.toList());
     }
 
-    private ConsolidatedAuditResult consolidateFirstBestResult(List<AuditResult> results) {
+    private ConsolidatedAuditResult consolidateFirstBestResult(AuditResultsGroupedByNino results) {
         AuditResult consolidatedResult = results.stream()
             .max(auditResultComparator)
             .orElse(null);

--- a/src/main/java/uk/gov/digital/ho/proving/income/audit/AuditResultConsolidator.java
+++ b/src/main/java/uk/gov/digital/ho/proving/income/audit/AuditResultConsolidator.java
@@ -47,7 +47,6 @@ public class AuditResultConsolidator {
             results.stream().collect(Collectors.groupingBy(AuditResult::nino));
 
         return resultsByNino.values().stream()
-                            .map(AuditResultsGroupedByNino::of)
                             .map(resultCutoffSeparator::separateResultsByCutoff)
                             .flatMap(Collection::stream)
                             .map(this::consolidateFirstBestResult)
@@ -55,7 +54,7 @@ public class AuditResultConsolidator {
                             .collect(Collectors.toList());
     }
 
-    private ConsolidatedAuditResult consolidateFirstBestResult(AuditResultsGroupedByNino results) {
+    private ConsolidatedAuditResult consolidateFirstBestResult(List<AuditResult> results) {
         AuditResult consolidatedResult = results.stream()
             .max(auditResultComparator)
             .orElse(null);

--- a/src/main/java/uk/gov/digital/ho/proving/income/audit/AuditResultConsolidator.java
+++ b/src/main/java/uk/gov/digital/ho/proving/income/audit/AuditResultConsolidator.java
@@ -46,11 +46,24 @@ public class AuditResultConsolidator {
         Map<String, List<AuditResult>> resultsByNino =
             results.stream().collect(Collectors.groupingBy(AuditResult::nino));
 
-        return resultsByNino.values().stream()
+        List<AuditResultsGroupedByNino> groupedByNino = groupByNino(resultsByNino.values());
+
+        return separateByCutoff(groupedByNino).stream()
+                                              .map(this::consolidateFirstBestResult)
+                                              .filter(Objects::nonNull)
+                                              .collect(Collectors.toList());
+    }
+
+    private List<AuditResultsGroupedByNino> groupByNino(Collection<List<AuditResult>> resultsByNino) {
+        return resultsByNino.stream()
+                            .map(AuditResultsGroupedByNino::of)
+                            .collect(Collectors.toList());
+    }
+
+    private List<List<AuditResult>> separateByCutoff(List<AuditResultsGroupedByNino> resultsByNino) {
+        return resultsByNino.stream()
                             .map(resultCutoffSeparator::separateResultsByCutoff)
                             .flatMap(Collection::stream)
-                            .map(this::consolidateFirstBestResult)
-                            .filter(Objects::nonNull)
                             .collect(Collectors.toList());
     }
 

--- a/src/main/java/uk/gov/digital/ho/proving/income/audit/ResultCutoffSeparator.java
+++ b/src/main/java/uk/gov/digital/ho/proving/income/audit/ResultCutoffSeparator.java
@@ -5,13 +5,11 @@ import org.springframework.stereotype.Component;
 import uk.gov.digital.ho.proving.income.audit.statistics.AuditResultsGroupedByNino;
 
 import java.util.ArrayList;
-import java.util.Collection;
 import java.util.Comparator;
 import java.util.List;
 import java.util.stream.Collectors;
 
 import static java.util.stream.Collectors.toCollection;
-import static java.util.stream.Collectors.toList;
 
 @Component
 public class ResultCutoffSeparator {

--- a/src/main/java/uk/gov/digital/ho/proving/income/audit/ResultCutoffSeparator.java
+++ b/src/main/java/uk/gov/digital/ho/proving/income/audit/ResultCutoffSeparator.java
@@ -5,11 +5,13 @@ import org.springframework.stereotype.Component;
 import uk.gov.digital.ho.proving.income.audit.statistics.AuditResultsGroupedByNino;
 
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.Comparator;
 import java.util.List;
 import java.util.stream.Collectors;
 
 import static java.util.stream.Collectors.toCollection;
+import static java.util.stream.Collectors.toList;
 
 @Component
 public class ResultCutoffSeparator {
@@ -18,6 +20,10 @@ public class ResultCutoffSeparator {
 
     public ResultCutoffSeparator(@Value("${audit.history.cutoff.days}") int cutoffDays) {
         this.cutoffDays = cutoffDays;
+    }
+
+    public List<AuditResultsGroupedByNino> separateResultsByCutoff(List<AuditResult> results) {
+        return separateResultsByCutoff(AuditResultsGroupedByNino.of(results));
     }
 
     public List<AuditResultsGroupedByNino> separateResultsByCutoff(AuditResultsGroupedByNino results) {

--- a/src/main/java/uk/gov/digital/ho/proving/income/audit/ResultCutoffSeparator.java
+++ b/src/main/java/uk/gov/digital/ho/proving/income/audit/ResultCutoffSeparator.java
@@ -22,10 +22,6 @@ public class ResultCutoffSeparator {
         this.cutoffDays = cutoffDays;
     }
 
-    public List<AuditResultsGroupedByNino> separateResultsByCutoff(List<AuditResult> results) {
-        return separateResultsByCutoff(AuditResultsGroupedByNino.of(results));
-    }
-
     public List<AuditResultsGroupedByNino> separateResultsByCutoff(AuditResultsGroupedByNino results) {
         AuditResultsGroupedByNino sortedByDate = sortByDate(results);
         List<AuditResultsGroupedByNino> groupedByCutoff = new ArrayList<>();

--- a/src/main/java/uk/gov/digital/ho/proving/income/audit/statistics/AuditResultsGroupedByNino.java
+++ b/src/main/java/uk/gov/digital/ho/proving/income/audit/statistics/AuditResultsGroupedByNino.java
@@ -4,6 +4,7 @@ import jersey.repackaged.com.google.common.collect.ForwardingList;
 import uk.gov.digital.ho.proving.income.audit.AuditResult;
 
 import java.time.LocalDate;
+import java.util.ArrayList;
 import java.util.List;
 
 import static java.util.Comparator.naturalOrder;
@@ -19,6 +20,10 @@ public class AuditResultsGroupedByNino extends ForwardingList<AuditResult> {
 
     public AuditResultsGroupedByNino(AuditResult result) {
         results = newArrayList(result);
+    }
+
+    public AuditResultsGroupedByNino(List<AuditResult> results) {
+        this.results = new ArrayList<>(results);
     }
 
     @Override
@@ -37,11 +42,5 @@ public class AuditResultsGroupedByNino extends ForwardingList<AuditResult> {
             return false;
         }
         return latestDate().plusDays(cutoffDays).isBefore(auditResult.date());
-    }
-
-    public static AuditResultsGroupedByNino of(List<AuditResult> results){
-        AuditResultsGroupedByNino groupedByNino = new AuditResultsGroupedByNino();
-        groupedByNino.addAll(results);
-        return groupedByNino;
     }
 }

--- a/src/main/java/uk/gov/digital/ho/proving/income/audit/statistics/AuditResultsGroupedByNino.java
+++ b/src/main/java/uk/gov/digital/ho/proving/income/audit/statistics/AuditResultsGroupedByNino.java
@@ -38,4 +38,10 @@ public class AuditResultsGroupedByNino extends ForwardingList<AuditResult> {
         }
         return latestDate().plusDays(cutoffDays).isBefore(auditResult.date());
     }
+
+    public static AuditResultsGroupedByNino of(List<AuditResult> results){
+        AuditResultsGroupedByNino groupedByNino = new AuditResultsGroupedByNino();
+        groupedByNino.addAll(results);
+        return groupedByNino;
+    }
 }

--- a/src/test/java/uk/gov/digital/ho/proving/income/audit/AuditResultConsolidatorIT.java
+++ b/src/test/java/uk/gov/digital/ho/proving/income/audit/AuditResultConsolidatorIT.java
@@ -4,6 +4,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.junit4.SpringRunner;
@@ -23,7 +24,8 @@ import static uk.gov.digital.ho.proving.income.audit.AuditResultType.*;
     AuditResultParser.class,
     AuditResultComparator.class,
     AuditResultTypeComparator.class,
-    AuditResultConsolidator.class
+    AuditResultConsolidator.class,
+    ResultCutoffSeparator.class
 })
 @ContextConfiguration(classes = FileUtils.class)
 public class AuditResultConsolidatorIT {
@@ -34,6 +36,7 @@ public class AuditResultConsolidatorIT {
     ObjectMapper objectMapper;
     @Autowired
     FileUtils fileUtils;
+    @Value("${audit.history.cutoff.days}") int cutoffDays;
 
     /*
      * auditResultsByCorrelationId
@@ -278,6 +281,20 @@ public class AuditResultConsolidatorIT {
 
         assertThat(resultsByNino.size()).isEqualTo(2);
         assertThat(resultsByNino).contains(expected.get(0), expected.get(1));
+    }
+
+    @Test
+    public void byNino_oneNinoTwoRequests_moreThanCutoffBetween_twoResults() {
+        LocalDate firstRequestDate = LocalDate.now();
+        LocalDate afterCutoff = firstRequestDate.plusDays(cutoffDays + 1);
+        List<AuditResult> results = Arrays.asList(new AuditResult("any_correlation_id", firstRequestDate, "some_nino", PASS),
+                                                  new AuditResult("any_correlation_id_2", afterCutoff, "some_nino", FAIL));
+
+        List<ConsolidatedAuditResult> expected = Arrays.asList(new ConsolidatedAuditResult("some_nino", Collections.singletonList("any_correlation_id"), firstRequestDate, PASS),
+                                                               new ConsolidatedAuditResult("some_nino", Collections.singletonList("any_correlation_id_2"), afterCutoff, FAIL));
+
+        assertThat(auditResultConsolidator.consolidatedAuditResults(results))
+            .containsExactlyElementsOf(expected);
     }
 
     /*

--- a/src/test/java/uk/gov/digital/ho/proving/income/audit/AuditResultConsolidatorIT.java
+++ b/src/test/java/uk/gov/digital/ho/proving/income/audit/AuditResultConsolidatorIT.java
@@ -282,7 +282,7 @@ public class AuditResultConsolidatorIT {
     }
 
     @Test
-    public void byNino_oneNinoTwoRequests_moreThanCutoffBetween_twoResults() {
+    public void consolidate_oneNinoTwoRequests_moreThanCutoffBetween_twoResults() {
         LocalDate firstRequestDate = LocalDate.now();
         LocalDate afterCutoff = firstRequestDate.plusDays(cutoffDays + 1);
         List<AuditResult> results = Arrays.asList(new AuditResult("any_correlation_id", firstRequestDate, "some_nino", PASS),

--- a/src/test/java/uk/gov/digital/ho/proving/income/audit/statistics/AuditResultsGroupedByNinoTest.java
+++ b/src/test/java/uk/gov/digital/ho/proving/income/audit/statistics/AuditResultsGroupedByNinoTest.java
@@ -6,6 +6,8 @@ import uk.gov.digital.ho.proving.income.audit.AuditResultType;
 
 import java.time.LocalDate;
 import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
 
 import static java.util.stream.Collectors.toCollection;
 import static org.assertj.core.api.Assertions.assertThat;
@@ -22,6 +24,12 @@ public class AuditResultsGroupedByNinoTest {
     @Test
     public void constructor_noArgs_empty() {
         assertThat(new AuditResultsGroupedByNino()).isEmpty();
+    }
+
+    @Test
+    public void constructor_withResults_containsResults() {
+        List<AuditResult> results = Collections.singletonList(ANY_RESULT);
+        assertThat(new AuditResultsGroupedByNino(results)).containsExactlyElementsOf(results);
     }
 
     @Test


### PR DESCRIPTION
Make the Audit Archive respect cutoff date i.e. if a request for the same nino is after the cutoff date, it is archived as separate request.

As this is a change to functionality I will not merge when approved.

I think this PR will conflict with https://github.com/UKHomeOffice/pttg-ip-api/pull/172 and whoever tests EE-21001 will probably want to test both at the same time. For this reason I will probably follow this PR with a large one combining the two, then close these PRs.