### PR TITLE
Ee 6825 accept test nino smoke test

### DIFF
--- a/src/main/java/uk/gov/digital/ho/proving/income/api/FinancialStatusResource.java
+++ b/src/main/java/uk/gov/digital/ho/proving/income/api/FinancialStatusResource.java
@@ -29,16 +29,19 @@ public class FinancialStatusResource {
     private FinancialStatusService financialStatusService;
     private final AuditClient auditClient;
     private final NinoUtils ninoUtils;
+    private final RequestData requestData;
 
     private static final int MINIMUM_DEPENDANTS = 0;
     private static final int MAXIMUM_DEPENDANTS = 99;
 
     private static final int NUMBER_OF_DAYS_INCOME = 365;
 
-    public FinancialStatusResource(FinancialStatusService financialStatusService, AuditClient auditClient, NinoUtils ninoUtils) {
+    public FinancialStatusResource(FinancialStatusService financialStatusService, AuditClient auditClient, NinoUtils ninoUtils,
+                                   RequestData requestData) {
         this.financialStatusService = financialStatusService;
         this.auditClient = auditClient;
         this.ninoUtils = ninoUtils;
+        this.requestData = requestData;
     }
 
     @PostMapping(value = "/incomeproving/v3/individual/financialstatus", produces = APPLICATION_JSON_VALUE)
@@ -81,6 +84,11 @@ public class FinancialStatusResource {
 
         if (applicants.size() > 2) {
             throw new IllegalArgumentException("Error: more than 2 applicants");
+        }
+
+        if (requestData.isASmokeTest()) {
+            // Smoke Tests intentionally use an invalid Nino but we want the request to pass through regardless, so skip Nino validation.
+            return;
         }
 
         for(Applicant applicant : applicants) {

--- a/src/main/java/uk/gov/digital/ho/proving/income/api/RequestData.java
+++ b/src/main/java/uk/gov/digital/ho/proving/income/api/RequestData.java
@@ -22,7 +22,7 @@ public class RequestData implements HandlerInterceptor {
     public static final String USER_ID_HEADER = "x-auth-userid";
     private static final String REQUEST_START_TIMESTAMP = "request-timestamp";
     public static final String REQUEST_DURATION_MS = "request_duration_ms";
-    private static final String SMOKE_TESTS_USER_ID = "smoke-tests";
+    public static final String SMOKE_TESTS_USER_ID = "smoke-tests";
 
     @Value("${auditing.deployment.name}") private String deploymentName;
     @Value("${auditing.deployment.namespace}") private String deploymentNamespace;

--- a/src/main/java/uk/gov/digital/ho/proving/income/api/RequestData.java
+++ b/src/main/java/uk/gov/digital/ho/proving/income/api/RequestData.java
@@ -22,6 +22,7 @@ public class RequestData implements HandlerInterceptor {
     public static final String USER_ID_HEADER = "x-auth-userid";
     private static final String REQUEST_START_TIMESTAMP = "request-timestamp";
     public static final String REQUEST_DURATION_MS = "request_duration_ms";
+    private static final String SMOKE_TESTS_USER_ID = "smoke-tests";
 
     @Value("${auditing.deployment.name}") private String deploymentName;
     @Value("${auditing.deployment.namespace}") private String deploymentNamespace;
@@ -98,5 +99,9 @@ public class RequestData implements HandlerInterceptor {
 
     public String userId() {
         return MDC.get(USER_ID_HEADER);
+    }
+
+    public boolean isASmokeTest() {
+        return userId().equals(SMOKE_TESTS_USER_ID);
     }
 }

--- a/src/test/groovy/uk/gov/digital/ho/proving/income/api/test/FinancialServiceSpec.groovy
+++ b/src/test/groovy/uk/gov/digital/ho/proving/income/api/test/FinancialServiceSpec.groovy
@@ -7,6 +7,7 @@ import spock.lang.Specification
 import uk.gov.digital.ho.proving.income.api.FinancialStatusResource
 import uk.gov.digital.ho.proving.income.api.FinancialStatusService
 import uk.gov.digital.ho.proving.income.api.NinoUtils
+import uk.gov.digital.ho.proving.income.api.RequestData
 import uk.gov.digital.ho.proving.income.api.domain.CategoryCheck
 import uk.gov.digital.ho.proving.income.api.domain.CheckedIndividual
 import uk.gov.digital.ho.proving.income.application.ApplicationExceptions
@@ -38,9 +39,10 @@ class FinancialServiceSpec extends Specification {
     def mockAuditClient = Mock(AuditClient)
     def mockNinoUtils = Mock(NinoUtils)
     def mockIncomeValidationService = Mock(IncomeValidationService)
+    def mockRequestData = Mock(RequestData)
 
     def financialStatusServiceHelper = new FinancialStatusService(mockIncomeRecordService, mockIncomeValidationService)
-    def financialStatusController = new FinancialStatusResource(financialStatusServiceHelper, mockAuditClient, mockNinoUtils)
+    def financialStatusController = new FinancialStatusResource(financialStatusServiceHelper, mockAuditClient, mockNinoUtils, mockRequestData)
 
     MockMvc mockMvc = standaloneSetup(financialStatusController).setControllerAdvice(new ResourceExceptionHandler(mockAuditClient, mockNinoUtils)).build()
 

--- a/src/test/java/uk/gov/digital/ho/proving/income/api/FinancialStatusResourceTest.java
+++ b/src/test/java/uk/gov/digital/ho/proving/income/api/FinancialStatusResourceTest.java
@@ -12,7 +12,6 @@ import org.junit.runner.RunWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnitRunner;
-import org.mockito.stubbing.OngoingStubbing;
 import org.slf4j.LoggerFactory;
 import uk.gov.digital.ho.proving.income.api.domain.*;
 import uk.gov.digital.ho.proving.income.application.LogEvent;

--- a/src/test/java/uk/gov/digital/ho/proving/income/api/FinancialStatusResourceWebTest.java
+++ b/src/test/java/uk/gov/digital/ho/proving/income/api/FinancialStatusResourceWebTest.java
@@ -1,0 +1,79 @@
+package uk.gov.digital.ho.proving.income.api;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.junit4.SpringRunner;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.web.client.RestTemplate;
+import uk.gov.digital.ho.proving.income.api.domain.Applicant;
+import uk.gov.digital.ho.proving.income.api.domain.FinancialStatusCheckResponse;
+import uk.gov.digital.ho.proving.income.api.domain.FinancialStatusRequest;
+import uk.gov.digital.ho.proving.income.api.domain.ResponseStatus;
+import uk.gov.digital.ho.proving.income.audit.AuditClient;
+
+import java.time.LocalDate;
+import java.util.List;
+
+import static java.util.Collections.*;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@RunWith(SpringRunner.class)
+@WebMvcTest({FinancialStatusResource.class, NinoUtils.class})
+public class FinancialStatusResourceWebTest {
+
+    private static final String SMOKE_TEST_NINO = "QQ123456C";
+
+    @Autowired
+    private ObjectMapper objectMapper;
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockBean private FinancialStatusService mockFinancialStatusService;
+    @MockBean private AuditClient mockAuditClient;
+    @MockBean private RestTemplate mockRestTemplate;
+
+    @Test
+    public void getFinancialStatus_smokeTestNino_smokeTest_returnOk() throws Exception {
+        when(mockFinancialStatusService.getIncomeRecords(anyList(), any(LocalDate.class), any(LocalDate.class)))
+            .thenReturn(emptyMap());
+        when(mockFinancialStatusService.calculateResponse(any(LocalDate.class), anyInt(), eq(emptyMap())))
+            .thenReturn(new FinancialStatusCheckResponse(new ResponseStatus("any", "any"), emptyList(), emptyList()));
+
+        mockMvc.perform(post("/incomeproving/v3/individual/financialstatus")
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(requestWithTestNino())
+                            .header(RequestData.USER_ID_HEADER, RequestData.SMOKE_TESTS_USER_ID))
+               .andExpect(status().isOk());
+    }
+
+    @Test
+    public void getFinancialStatus_smokeTestNino_notASmokeTest_returnBadRequest() throws Exception {
+        when(mockFinancialStatusService.getIncomeRecords(anyList(), any(LocalDate.class), any(LocalDate.class)))
+            .thenReturn(emptyMap());
+        when(mockFinancialStatusService.calculateResponse(any(LocalDate.class), anyInt(), eq(emptyMap())))
+            .thenReturn(new FinancialStatusCheckResponse(new ResponseStatus("any", "any"), emptyList(), emptyList()));
+
+        mockMvc.perform(post("/incomeproving/v3/individual/financialstatus")
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(requestWithTestNino())
+                            .header(RequestData.USER_ID_HEADER, "not a smoke test user"))
+               .andExpect(status().isBadRequest())
+               .andExpect(jsonPath("$.status.code").value("0004"));
+    }
+
+    private String requestWithTestNino() throws JsonProcessingException {
+        LocalDate anyDateOfBirth = LocalDate.now();
+        List<Applicant> applicant = singletonList(new Applicant("any forename", "any surname", anyDateOfBirth, SMOKE_TEST_NINO));
+        return objectMapper.writeValueAsString(new FinancialStatusRequest(applicant, LocalDate.now(), 0));
+    }
+}

--- a/src/test/java/uk/gov/digital/ho/proving/income/api/FinancialStatusResourceWebTest.java
+++ b/src/test/java/uk/gov/digital/ho/proving/income/api/FinancialStatusResourceWebTest.java
@@ -10,6 +10,7 @@ import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.http.MediaType;
 import org.springframework.test.context.junit4.SpringRunner;
 import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.request.MockHttpServletRequestBuilder;
 import org.springframework.web.client.RestTemplate;
 import uk.gov.digital.ho.proving.income.api.domain.Applicant;
 import uk.gov.digital.ho.proving.income.api.domain.FinancialStatusCheckResponse;
@@ -49,10 +50,7 @@ public class FinancialStatusResourceWebTest {
         when(mockFinancialStatusService.calculateResponse(any(LocalDate.class), anyInt(), eq(emptyMap())))
             .thenReturn(new FinancialStatusCheckResponse(new ResponseStatus("any", "any"), emptyList(), emptyList()));
 
-        mockMvc.perform(post("/incomeproving/v3/individual/financialstatus")
-                            .contentType(MediaType.APPLICATION_JSON)
-                            .content(requestWithTestNino())
-                            .header(RequestData.USER_ID_HEADER, RequestData.SMOKE_TESTS_USER_ID))
+        mockMvc.perform(financialStatusRequest(RequestData.SMOKE_TESTS_USER_ID))
                .andExpect(status().isOk());
     }
 
@@ -63,12 +61,16 @@ public class FinancialStatusResourceWebTest {
         when(mockFinancialStatusService.calculateResponse(any(LocalDate.class), anyInt(), eq(emptyMap())))
             .thenReturn(new FinancialStatusCheckResponse(new ResponseStatus("any", "any"), emptyList(), emptyList()));
 
-        mockMvc.perform(post("/incomeproving/v3/individual/financialstatus")
-                            .contentType(MediaType.APPLICATION_JSON)
-                            .content(requestWithTestNino())
-                            .header(RequestData.USER_ID_HEADER, "not a smoke test user"))
+        mockMvc.perform(financialStatusRequest("not a smoke test user"))
                .andExpect(status().isBadRequest())
                .andExpect(jsonPath("$.status.code").value("0004"));
+    }
+
+    private MockHttpServletRequestBuilder financialStatusRequest(String userId) throws JsonProcessingException {
+        return post("/incomeproving/v3/individual/financialstatus")
+            .contentType(MediaType.APPLICATION_JSON)
+            .content(requestWithTestNino())
+            .header(RequestData.USER_ID_HEADER, userId);
     }
 
     private String requestWithTestNino() throws JsonProcessingException {

--- a/src/test/java/uk/gov/digital/ho/proving/income/api/RequestDataTest.java
+++ b/src/test/java/uk/gov/digital/ho/proving/income/api/RequestDataTest.java
@@ -1,7 +1,10 @@
 package uk.gov.digital.ho.proving.income.api;
 
+import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
 import org.slf4j.MDC;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
@@ -12,7 +15,6 @@ import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 import static uk.gov.digital.ho.proving.income.api.RequestData.*;
 
@@ -26,12 +28,18 @@ public class RequestDataTest {
 
     @Autowired
     private RequestData requestData;
+    @Mock
+    private HttpServletRequest mockRequest;
+    @Mock
+    private HttpServletResponse mockResponse;
+
+    @Before
+    public void setUp() {
+        MockitoAnnotations.initMocks(this);
+    }
 
     @Test
-    public void shouldConfigureMDC_preHandle() throws Exception {
-        HttpServletRequest mockRequest = mock(HttpServletRequest.class);
-        HttpServletResponse mockResponse = mock(HttpServletResponse.class);
-
+    public void shouldConfigureMDC_preHandle() {
         requestData.preHandle(mockRequest, mockResponse, null);
 
         assertThat(MDC.get(SESSION_ID_HEADER)).isEqualTo("unknown");
@@ -39,11 +47,8 @@ public class RequestDataTest {
     }
 
     @Test
-    public void shouldResetMDC_postHandle() throws Exception {
-        HttpServletRequest request = mock(HttpServletRequest.class);
-        HttpServletResponse response = mock(HttpServletResponse.class);
-
-        requestData.preHandle(request, response, null);
+    public void shouldResetMDC_postHandle() {
+        requestData.preHandle(mockRequest, mockResponse, null);
         requestData.postHandle(null, null, null, null);
 
         assertThat(MDC.get(SESSION_ID_HEADER)).isNull();
@@ -71,20 +76,14 @@ public class RequestDataTest {
     }
 
     @Test
-    public void shouldExposeSessionId() throws Exception {
-        HttpServletRequest mockRequest = mock(HttpServletRequest.class);
-        HttpServletResponse mockResponse = mock(HttpServletResponse.class);
-
+    public void shouldExposeSessionId() {
         requestData.preHandle(mockRequest, mockResponse, null);
 
         assertThat(requestData.sessionId()).isEqualTo("unknown");
     }
 
     @Test
-    public void shouldExposeCorrelationId() throws Exception {
-        HttpServletRequest mockRequest = mock(HttpServletRequest.class);
-        HttpServletResponse mockResponse = mock(HttpServletResponse.class);
-
+    public void shouldExposeCorrelationId() {
         when(mockRequest.getHeader(CORRELATION_ID_HEADER)).thenReturn("some correlation id");
 
         requestData.preHandle(mockRequest, mockResponse, null);
@@ -93,14 +92,30 @@ public class RequestDataTest {
     }
 
     @Test
-    public void shouldExposeUserId() throws Exception {
-        HttpServletRequest mockRequest = mock(HttpServletRequest.class);
-        HttpServletResponse mockResponse = mock(HttpServletResponse.class);
-
+    public void shouldExposeUserId() {
         when(mockRequest.getHeader(USER_ID_HEADER)).thenReturn("some user id");
 
         requestData.preHandle(mockRequest, mockResponse, null);
 
         assertThat(requestData.userId()).isEqualTo("some user id");
+    }
+
+    @Test
+    public void isASmokeTest_smokeTestUser_returnTrue() {
+        when(mockRequest.getHeader(USER_ID_HEADER)).thenReturn("smoke-tests");
+
+        requestData.preHandle(mockRequest, mockResponse, null);
+
+        assertThat(requestData.isASmokeTest()).isTrue();
+    }
+
+    @Test
+    public void isASmokeTest_notSmokeTestUser_returnFalse() {
+        when(mockRequest.getHeader(USER_ID_HEADER)).thenReturn("some not a smoke test user");
+
+        requestData.preHandle(mockRequest, mockResponse, null);
+
+        assertThat(requestData.isASmokeTest()).isFalse();
+
     }
 }


### PR DESCRIPTION
Making it so that Nino validation is skipped if the user-id is the one used by the smoke tests.

I intend to merge once approved.