### PR TITLE
Ee 6825 retry integration test

### DIFF
--- a/src/main/java/uk/gov/digital/ho/proving/income/audit/AuditClient.java
+++ b/src/main/java/uk/gov/digital/ho/proving/income/audit/AuditClient.java
@@ -66,6 +66,10 @@ public class AuditClient {
         this.mapper = mapper;
     }
 
+    @Retryable(
+        value = {RestClientException.class},
+        maxAttemptsExpression = "#{${audit.service.retry.attempts}}",
+        backoff = @Backoff(delayExpression = "#{${audit.service.retry.delay}}"))
     public void add(AuditEventType eventType, UUID eventId, Map<String, Object> auditDetail) {
 
         log.info("POST data for {} to audit service", eventId, value(EVENT, INCOME_PROVING_AUDIT_REQUEST));
@@ -79,10 +83,6 @@ public class AuditClient {
         }
     }
 
-    @Retryable(
-            value = { RestClientException.class },
-            maxAttemptsExpression = "#{${audit.service.retry.attempts}}",
-            backoff = @Backoff(delayExpression = "#{${audit.service.retry.delay}}"))
     private void dispatchAuditableData(AuditableData auditableData) {
         restTemplate.exchange(auditEndpoint, POST, toEntity(auditableData), Void.class);
     }

--- a/src/main/java/uk/gov/digital/ho/proving/income/hmrc/domain/HmrcIndividual.java
+++ b/src/main/java/uk/gov/digital/ho/proving/income/hmrc/domain/HmrcIndividual.java
@@ -3,6 +3,7 @@ package uk.gov.digital.ho.proving.income.hmrc.domain;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import lombok.AllArgsConstructor;
+import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.experimental.Accessors;
 
@@ -12,6 +13,7 @@ import java.time.LocalDate;
 @AllArgsConstructor
 @Accessors(fluent = true)
 @JsonIgnoreProperties(ignoreUnknown = true)
+@EqualsAndHashCode
 public class HmrcIndividual {
     @JsonProperty
     private String firstName;

--- a/src/main/java/uk/gov/digital/ho/proving/income/hmrc/domain/IncomeRecord.java
+++ b/src/main/java/uk/gov/digital/ho/proving/income/hmrc/domain/IncomeRecord.java
@@ -3,6 +3,7 @@ package uk.gov.digital.ho.proving.income.hmrc.domain;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import lombok.AllArgsConstructor;
+import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.experimental.Accessors;
 
@@ -15,6 +16,7 @@ import static java.util.stream.Collectors.toList;
 @Getter
 @Accessors(fluent = true)
 @JsonIgnoreProperties(ignoreUnknown = true)
+@EqualsAndHashCode
 public class IncomeRecord {
 
     @JsonProperty(value = "paye", required = true)

--- a/src/test/java/uk/gov/digital/ho/proving/income/audit/AuditClientRetryTest.java
+++ b/src/test/java/uk/gov/digital/ho/proving/income/audit/AuditClientRetryTest.java
@@ -1,0 +1,63 @@
+package uk.gov.digital.ho.proving.income.audit;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.junit4.SpringRunner;
+import org.springframework.test.web.client.MockRestServiceServer;
+import org.springframework.web.client.HttpServerErrorException;
+import org.springframework.web.client.RestTemplate;
+import uk.gov.digital.ho.proving.income.ServiceRunner;
+
+import java.util.Collections;
+import java.util.Map;
+import java.util.UUID;
+
+import static java.util.Collections.emptyMap;
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.hamcrest.Matchers.containsString;
+import static org.springframework.http.HttpStatus.INTERNAL_SERVER_ERROR;
+import static org.springframework.test.web.client.ExpectedCount.times;
+import static org.springframework.test.web.client.match.MockRestRequestMatchers.requestTo;
+import static org.springframework.test.web.client.response.MockRestResponseCreators.withStatus;
+import static org.springframework.test.web.client.response.MockRestResponseCreators.withSuccess;
+import static uk.gov.digital.ho.proving.income.audit.AuditEventType.INCOME_PROVING_FINANCIAL_STATUS_REQUEST;
+
+@RunWith(SpringRunner.class)
+@SpringBootTest(classes = ServiceRunner.class)
+public class AuditClientRetryTest {
+
+    private static final AuditEventType ANY_EVENT_TYPE = INCOME_PROVING_FINANCIAL_STATUS_REQUEST;
+    private static final UUID ANY_UUID = UUID.randomUUID();
+    private static final Map<String, Object> ANY_MAP = emptyMap();
+
+    @Autowired
+    public RestTemplate restTemplate;
+
+    @Autowired
+    public ObjectMapper objectMapper;
+
+    @Autowired
+    public AuditClient auditClient;
+
+    private MockRestServiceServer auditMockService;
+
+    @Before
+    public void setUp() {
+        auditMockService = MockRestServiceServer.bindTo(restTemplate).build();
+    }
+
+    @Test
+    public void add_httpException_shouldRetry() {
+        auditMockService.expect(times(4), requestTo(containsString("/audit")))
+                        .andRespond(withStatus(INTERNAL_SERVER_ERROR));
+        auditMockService.expect(requestTo(containsString("/audit")))
+                        .andRespond(withSuccess());
+
+        assertThatCode(() -> auditClient.add(ANY_EVENT_TYPE, ANY_UUID, ANY_MAP)).doesNotThrowAnyException();
+        auditMockService.verify();
+    }
+}

--- a/src/test/java/uk/gov/digital/ho/proving/income/hmrc/HmrcClientRetryTest.java
+++ b/src/test/java/uk/gov/digital/ho/proving/income/hmrc/HmrcClientRetryTest.java
@@ -1,0 +1,70 @@
+package uk.gov.digital.ho.proving.income.hmrc;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.junit4.SpringRunner;
+import org.springframework.test.web.client.MockRestServiceServer;
+import org.springframework.web.client.RestTemplate;
+import uk.gov.digital.ho.proving.income.ServiceRunner;
+import uk.gov.digital.ho.proving.income.hmrc.domain.HmrcIndividual;
+import uk.gov.digital.ho.proving.income.hmrc.domain.Identity;
+import uk.gov.digital.ho.proving.income.hmrc.domain.IncomeRecord;
+
+import java.time.LocalDate;
+
+import static java.util.Collections.emptyList;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.hamcrest.Matchers.containsString;
+import static org.springframework.http.HttpStatus.INTERNAL_SERVER_ERROR;
+import static org.springframework.test.web.client.match.MockRestRequestMatchers.requestTo;
+import static org.springframework.test.web.client.response.MockRestResponseCreators.withStatus;
+import static org.springframework.test.web.client.response.MockRestResponseCreators.withSuccess;
+
+@RunWith(SpringRunner.class)
+@SpringBootTest(classes = ServiceRunner.class)
+public class HmrcClientRetryTest {
+
+    private static final LocalDate ANY_DATE = LocalDate.now();
+    private static final Identity ANY_IDENTITY = new Identity("any name", "any name", ANY_DATE, "any nino");
+    private static final HmrcIndividual ANY_INDIVIDUAL = new HmrcIndividual("any name", "any name", "any nino", ANY_DATE);
+    private static final IncomeRecord EXPECTED_INCOME_RECORD = new IncomeRecord(emptyList(), emptyList(), emptyList(), ANY_INDIVIDUAL);
+
+    @Autowired
+    public RestTemplate restTemplate;
+
+    @Autowired
+    public ObjectMapper objectMapper;
+
+    @Autowired
+    public HmrcClient hmrcClient;
+
+    private MockRestServiceServer hmrcMockService;
+
+    @Before
+    public void setUp() {
+        hmrcMockService = MockRestServiceServer.bindTo(restTemplate).build();
+    }
+
+    @Test
+    public void getIncomeRecord_serverError_shouldRetry() throws JsonProcessingException {
+        hmrcMockService.expect(requestTo(containsString("/income")))
+                       .andRespond(withStatus(INTERNAL_SERVER_ERROR));
+        hmrcMockService.expect(requestTo(containsString("/income")))
+                       .andRespond(withStatus(INTERNAL_SERVER_ERROR));
+        hmrcMockService.expect(requestTo(containsString("/income")))
+                       .andRespond(withSuccess(hmrcSuccessResponse(), MediaType.APPLICATION_JSON));
+
+        IncomeRecord actualIncomeRecord = hmrcClient.getIncomeRecord(ANY_IDENTITY, ANY_DATE, ANY_DATE);
+        assertThat(actualIncomeRecord).isEqualTo(EXPECTED_INCOME_RECORD);
+    }
+
+    private String hmrcSuccessResponse() throws JsonProcessingException {
+        return objectMapper.writeValueAsString(EXPECTED_INCOME_RECORD);
+    }
+}


### PR DESCRIPTION
Added integration tests to confirm that the @Retryable annotations on HmrcClient and AuditClient behave as expected. This showed that the AuditClient wasn't retrying on errors because the @Retryable annotation was on an method called internally in AuditClient. I have fixed this but as a change has been made this PR should be tested before merging.