### PR TITLE
EE-6825 Run Smoke Tests

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -156,3 +156,20 @@ pipeline:
     when:
       event: deployment
       environment: pr
+
+  run-smoke-tests-non-prod:
+      image: quay.io/ukhomeofficedigital/kd:v1.14.0
+      secrets:
+          - pttg_ip_dev
+      environment:
+          - KUBE_NAMESPACE=pttg-ip-${DRONE_DEPLOY_TO}
+          - ENVIRONMENT=${DRONE_DEPLOY_TO}
+      commands:
+          - kubectl config set-cluster nonprod --insecure-skip-tls-verify=true --server=https://kube-api-notprod.notprod.acp.homeoffice.gov.uk
+          - kubectl config set-context ips-$${ENVIRONMENT} --cluster=nonprod --namespace=$${KUBE_NAMESPACE}
+          - kubectl config use-context ips-$${ENVIRONMENT}
+          - SMOKE_TEST_POD=$(kubectl --token="$${PTTG_IP_DEV}" get pods | grep pttg-ip-smoke-tests | head -n 1 | cut -d ' ' -f 1)
+          - kubectl --token="$${PTTG_IP_DEV}" exec "$${SMOKE_TEST_POD}" -- curl --fail -X POST 'http://localhost:8080/smoketests'
+      when:
+          event: deployment
+          environment: [dev, test, feat1, feat2, feat3, preprod]


### PR DESCRIPTION
 Adding drone config to run smoke tests after a deployment to a non-prod environment. I won't merge this but put it on the JIRA